### PR TITLE
Fixed bugs in the preferences

### DIFF
--- a/Caboodle/Preferences/Preferences.android.cs
+++ b/Caboodle/Preferences/Preferences.android.cs
@@ -88,9 +88,6 @@ namespace Microsoft.Caboodle
 				{
 					switch (defaultValue)
 					{
-						case string s:
-							value = sharedPreferences.GetString(key, s);
-							break;
 						case int i:
 							value = sharedPreferences.GetInt(key, i);
 							break;
@@ -120,6 +117,15 @@ namespace Microsoft.Caboodle
 							break;
 						case float f:
 							value = sharedPreferences.GetFloat(key, f);
+							break;
+						case string s:
+							// the case when the string is not null
+							value = sharedPreferences.GetString(key, s);
+							break;
+						default:
+							// the case when the string is null
+							if (typeof(T) == typeof(string))
+								value = sharedPreferences.GetString(key, null);
 							break;
 					}
 				}

--- a/Caboodle/Preferences/Preferences.ios.cs
+++ b/Caboodle/Preferences/Preferences.ios.cs
@@ -79,11 +79,8 @@ namespace Microsoft.Caboodle
 
 				switch (defaultValue)
 				{
-					case string s:
-						value = UserDefaults.StringForKey(key);
-						break;
 					case int i:
-						value = UserDefaults.IntForKey(key);
+						value = (int)(nint)UserDefaults.IntForKey(key);
 						break;
 					case bool b:
 						value = UserDefaults.BoolForKey(key);
@@ -97,6 +94,15 @@ namespace Microsoft.Caboodle
 						break;
 					case float f:
 						value = UserDefaults.FloatForKey(key);
+						break;
+					case string s:
+						// the case when the string is not null
+						value = UserDefaults.StringForKey(key);
+						break;
+					default:
+						// the case when the string is null
+						if (typeof(T) == typeof(string))
+							value = UserDefaults.StringForKey(key);
 						break;
 				}
 			}

--- a/Caboodle/Preferences/Preferences.uwp.cs
+++ b/Caboodle/Preferences/Preferences.uwp.cs
@@ -61,12 +61,17 @@ namespace Microsoft.Caboodle
 			{
 				if (settings == null)
 				{
+					var localSettings = ApplicationData.Current.LocalSettings;
 					if (string.IsNullOrWhiteSpace(SharedName))
-						settings = ApplicationData.Current.LocalSettings;
-
-					if (!ApplicationData.Current.LocalSettings.Containers.ContainsKey(SharedName))
-						ApplicationData.Current.LocalSettings.CreateContainer(SharedName, ApplicationDataCreateDisposition.Always);
-					settings = ApplicationData.Current.LocalSettings.Containers[SharedName];
+					{
+						settings = localSettings;
+					}
+					else
+					{
+						if (!localSettings.Containers.ContainsKey(SharedName))
+							localSettings.CreateContainer(SharedName, ApplicationDataCreateDisposition.Always);
+						settings = localSettings.Containers[SharedName];
+					}
 				}
 
 				return settings;


### PR DESCRIPTION
 - Android/iOS: if the default value was `null`, then the `case string s` would not be true
 - UWP: don't try using the shared name if it was null