### PR TITLE
Added a build script for CI bots

### DIFF
--- a/Caboodle/Types/LocationExtensions.shared.cs
+++ b/Caboodle/Types/LocationExtensions.shared.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Caboodle.Types
+namespace Microsoft.Caboodle
 {
     public static partial class LocationExtensions
     {

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = "Stop"
+
+# Find MSBuild on this machine
+if ($IsMacOS) {
+    $msbuild = "msbuild"
+} else {
+    $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+    $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+    $msbuild = join-path $msbuild 'MSBuild\15.0\Bin\MSBuild.exe'
+}
+
+Write-Output "Using MSBuild from: $msbuild"
+
+# Build the projects
+& $msbuild "./Caboodle.sln" /t:"Restore;Build" /p:Configuration=Release
+if ($lastexitcode -ne 0) { exit $lastexitcode; }
+
+# Create the stable NuGet package
+& $msbuild "./Caboodle/Caboodle.csproj" /t:Pack /p:Configuration=Release /p:VersionSuffix=".$env:BUILD_NUMBER"
+if ($lastexitcode -ne 0) { exit $lastexitcode; }
+
+# Create the beta NuGet package
+& $msbuild "./Caboodle/Caboodle.csproj" /t:Pack /p:Configuration=Release /p:VersionSuffix=".$env:BUILD_NUMBER-beta"
+if ($lastexitcode -ne 0) { exit $lastexitcode; }
+
+# Copy everything into the output folder
+Copy-Item "./Caboodle/bin/Release" "./Output" -Recurse -Force
+
+exit $lastexitcode;


### PR DESCRIPTION
Added a simple PowerShell script that just runs Msbuild to restore, build, and package the library. This is for the CI bots just to run `./build.ps1`.

It is also useful for verifying that all is well before submitting a PR.