### PR TITLE
Work to move thread switching into the library

### DIFF
--- a/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Caboodle
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
 {
     public static partial class DeviceInfo
     {
@@ -24,7 +26,7 @@
 
         static DeviceType GetDeviceType() => throw new NotImplentedInReferenceAssembly();
 
-        static ScreenMetrics GetScreenMetrics() => throw new NotImplentedInReferenceAssembly();
+        static Task<ScreenMetrics> GetScreenMetricsAsyncInternal() => throw new NotImplentedInReferenceAssembly();
 
         static void StartScreenMetricsListeners() => throw new NotImplentedInReferenceAssembly();
 

--- a/Caboodle/DeviceInfo/DeviceInfo.shared.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.shared.cs
@@ -1,52 +1,39 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Caboodle
 {
     public static partial class DeviceInfo
     {
-        static string model;
-        static string manufacturer;
-        static string deviceName;
-        static string versionString;
-        static Version versionNumber;
-        static string appName;
-        static string appPackageName;
-        static string appVersionString;
-        static Version appVersionNumber;
-        static string appBuild;
-        static string platform;
-        static string idiom;
-        static DeviceType? deviceType;
-
         static event ScreenMetricsChanagedEventHandler ScreenMetricsChanagedInternal;
 
-        public static string Model => model ?? (model = GetModel());
+        public static string Model => GetModel();
 
-        public static string Manufacturer => manufacturer ?? (manufacturer = GetManufacturer());
+        public static string Manufacturer => GetManufacturer();
 
-        public static string Name => deviceName ?? (deviceName = GetDeviceName());
+        public static string Name => GetDeviceName();
 
-        public static string VersionString => versionString ?? (versionString = GetVersionString());
+        public static string VersionString => GetVersionString();
 
-        public static Version Version => ParseVersion(VersionString, ref versionNumber);
+        public static Version Version => ParseVersion(VersionString);
 
-        public static string AppPackageName => appPackageName ?? (appPackageName = GetAppPackageName());
+        public static string AppPackageName => GetAppPackageName();
 
-        public static string AppName => appName ?? (appName = GetAppName());
+        public static string AppName => GetAppName();
 
-        public static string AppVersionString => appVersionString ?? (appVersionString = GetAppVersionString());
+        public static string AppVersionString => GetAppVersionString();
 
-        public static Version AppVersion => ParseVersion(AppVersionString, ref appVersionNumber);
+        public static Version AppVersion => ParseVersion(AppVersionString);
 
-        public static string AppBuildString => appBuild ?? (appBuild = GetAppBuild());
+        public static string AppBuildString => GetAppBuild();
 
-        public static string Platform => platform ?? (platform = GetPlatform());
+        public static string Platform => GetPlatform();
 
-        public static string Idiom => idiom ?? (idiom = GetIdiom());
+        public static string Idiom => GetIdiom();
 
-        public static DeviceType DeviceType => deviceType ?? (deviceType = GetDeviceType()).Value;
+        public static DeviceType DeviceType => GetDeviceType();
 
-        public static ScreenMetrics ScreenMetrics => GetScreenMetrics();
+        public static Task<ScreenMetrics> GetScreenMetricsAsync() => GetScreenMetricsAsyncInternal();
 
         public static event ScreenMetricsChanagedEventHandler ScreenMetricsChanaged
         {
@@ -71,24 +58,18 @@ namespace Microsoft.Caboodle
             }
         }
 
-        static void OnScreenMetricsChanaged()
-            => OnScreenMetricsChanaged(ScreenMetrics);
-
         static void OnScreenMetricsChanaged(ScreenMetrics metrics)
             => OnScreenMetricsChanaged(new ScreenMetricsChanagedEventArgs(metrics));
 
         static void OnScreenMetricsChanaged(ScreenMetricsChanagedEventArgs e)
             => ScreenMetricsChanagedInternal?.Invoke(e);
 
-        static Version ParseVersion(string version, ref Version number)
+        static Version ParseVersion(string version)
         {
-            if (number != null)
+            if (Version.TryParse(version, out var number))
                 return number;
 
-            if (!Version.TryParse(version, out number))
-                number = new Version(0, 0);
-
-            return number;
+            return new Version(0, 0);
         }
 
         public static class Idioms

--- a/Caboodle/Platform/Platform.shared.cs
+++ b/Caboodle/Platform/Platform.shared.cs
@@ -1,6 +1,48 @@
-﻿namespace Microsoft.Caboodle
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
 {
     public static partial class Platform
     {
+        internal static Task InvokeOnMainThread(Action action)
+        {
+            var tcs = new TaskCompletionSource<object>();
+
+            BeginInvokeOnMainThread(() =>
+            {
+                try
+                {
+                    action();
+                    tcs.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            });
+
+            return tcs.Task;
+        }
+
+        internal static Task<T> InvokeOnMainThread<T>(Func<T> action)
+        {
+            var tcs = new TaskCompletionSource<T>();
+
+            BeginInvokeOnMainThread(() =>
+            {
+                try
+                {
+                    var result = action();
+                    tcs.TrySetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            });
+
+            return tcs.Task;
+        }
     }
 }

--- a/DeviceTests/Caboodle.DeviceTests.Shared/DeviceInfo_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/DeviceInfo_Tests.cs
@@ -67,16 +67,13 @@ namespace Caboodle.DeviceTests
         }
 
         [Fact]
-        public Task Screen_Metrics_Are_Not_Null()
+        public async Task Screen_Metrics_Are_Not_Null()
         {
-            return Utils.OnMainThread(() =>
-            {
-                var metrics = DeviceInfo.ScreenMetrics;
+            var metrics = await DeviceInfo.GetScreenMetricsAsync();
 
-                Assert.True(metrics.Width > 0);
-                Assert.True(metrics.Height > 0);
-                Assert.True(metrics.Density > 0);
-            });
+            Assert.True(metrics.Width > 0);
+            Assert.True(metrics.Height > 0);
+            Assert.True(metrics.Density > 0);
         }
     }
 }

--- a/Samples/Caboodle.Samples/View/BasePage.cs
+++ b/Samples/Caboodle.Samples/View/BasePage.cs
@@ -1,0 +1,32 @@
+﻿using Caboodle.Samples.ViewModel;
+using Xamarin.Forms;
+
+namespace Caboodle.Samples.View
+{
+    public class BasePage : ContentPage
+    {
+        public BasePage()
+        {
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            if (BindingContext is BaseViewModel vm)
+            {
+                vm.OnAppearing();
+            }
+        }
+
+        protected override void OnDisappearing()
+        {
+            if (BindingContext is BaseViewModel vm)
+            {
+                vm.OnDisappearing();
+            }
+
+            base.OnDisappearing();
+        }
+    }
+}

--- a/Samples/Caboodle.Samples/View/BatteryPage.xaml
+++ b/Samples/Caboodle.Samples/View/BatteryPage.xaml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Caboodle.Samples.View.BatteryPage"
-             Title="Battery"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.BatteryPage"
+                Title="Battery">
     <ContentPage.BindingContext>
-        <viewmodels:BatteryViewModel/>
+        <viewmodels:BatteryViewModel />
     </ContentPage.BindingContext>
 
     <StackLayout>
@@ -21,4 +22,4 @@
         </ScrollView>
     </StackLayout>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/BatteryPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/BatteryPage.xaml.cs
@@ -1,36 +1,10 @@
-﻿using Caboodle.Samples.ViewModel;
-using Microsoft.Caboodle;
-using Xamarin.Forms;
-
-namespace Caboodle.Samples.View
+﻿namespace Caboodle.Samples.View
 {
-    public partial class BatteryPage : ContentPage
+    public partial class BatteryPage : BasePage
     {
         public BatteryPage()
         {
             InitializeComponent();
-        }
-
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-
-            Battery.BatteryChanged += OnBatteryChanged;
-        }
-
-        protected override void OnDisappearing()
-        {
-            Battery.BatteryChanged -= OnBatteryChanged;
-
-            base.OnDisappearing();
-        }
-
-        void OnBatteryChanged(BatteryChangedEventArgs e)
-        {
-            if (BindingContext is BatteryViewModel vm)
-            {
-                vm.Update(e);
-            }
         }
     }
 }

--- a/Samples/Caboodle.Samples/View/DeviceInfoPage.xaml
+++ b/Samples/Caboodle.Samples/View/DeviceInfoPage.xaml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Caboodle.Samples.View.DeviceInfoPage"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
-             Title="Device Info">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.DeviceInfoPage"
+                Title="Device Info">
     <ContentPage.BindingContext>
-        <viewmodels:DeviceInfoViewModel/>
+        <viewmodels:DeviceInfoViewModel />
     </ContentPage.BindingContext>
 
     <StackLayout>
@@ -38,4 +39,4 @@
         </ScrollView>
     </StackLayout>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/DeviceInfoPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/DeviceInfoPage.xaml.cs
@@ -1,36 +1,10 @@
-﻿using Caboodle.Samples.ViewModel;
-using Microsoft.Caboodle;
-using Xamarin.Forms;
-
-namespace Caboodle.Samples.View
+﻿namespace Caboodle.Samples.View
 {
-    public partial class DeviceInfoPage : ContentPage
+    public partial class DeviceInfoPage : BasePage
     {
         public DeviceInfoPage()
         {
             InitializeComponent();
-        }
-
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-
-            DeviceInfo.ScreenMetricsChanaged += OnScreenMetricsChanged;
-        }
-
-        protected override void OnDisappearing()
-        {
-            DeviceInfo.ScreenMetricsChanaged -= OnScreenMetricsChanged;
-
-            base.OnDisappearing();
-        }
-
-        void OnScreenMetricsChanged(ScreenMetricsChanagedEventArgs e)
-        {
-            if (BindingContext is DeviceInfoViewModel vm)
-            {
-                vm.ScreenMetrics = e.Metrics;
-            }
         }
     }
 }

--- a/Samples/Caboodle.Samples/View/GeocodingPage.xaml
+++ b/Samples/Caboodle.Samples/View/GeocodingPage.xaml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Caboodle.Samples.View.GeocodingPage"
-             Title="Geocoding"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.GeocodingPage"
+                Title="Geocoding">
     <ContentPage.BindingContext>
         <viewmodels:GeocodingViewModel />
     </ContentPage.BindingContext>
@@ -32,4 +33,4 @@
         </ScrollView>
     </StackLayout>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/GeocodingPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/GeocodingPage.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace Caboodle.Samples.View
 {
-    public partial class GeocodingPage : ContentPage
+    public partial class GeocodingPage : BasePage
     {
         public GeocodingPage()
         {

--- a/Samples/Caboodle.Samples/View/HomePage.xaml
+++ b/Samples/Caboodle.Samples/View/HomePage.xaml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Caboodle.Samples.View.HomePage"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
-             Title="Caboodle Samples">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.HomePage"
+                Title="Caboodle Samples">
     <ContentPage.BindingContext>
-        <viewmodels:HomeViewModel/>
+        <viewmodels:HomeViewModel />
     </ContentPage.BindingContext>
 
     <ListView ItemsSource="{Binding Items}" ItemTapped="Handle_ItemTapped" CachingStrategy="RecycleElement">
@@ -16,4 +17,4 @@
         </ListView.ItemTemplate>
     </ListView>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/HomePage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/HomePage.xaml.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms;
 
 namespace Caboodle.Samples.View
 {
-    public partial class HomePage : ContentPage
+    public partial class HomePage : BasePage
     {
         public HomePage()
         {

--- a/Samples/Caboodle.Samples/View/PreferencesPage.xaml
+++ b/Samples/Caboodle.Samples/View/PreferencesPage.xaml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Caboodle.Samples.View.PreferencesPage"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
-             Title="Preferences">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.PreferencesPage"
+                Title="Preferences">
     <ContentPage.BindingContext>
-        <viewmodels:PreferencesViewModel/>
+        <viewmodels:PreferencesViewModel />
     </ContentPage.BindingContext>
 
     <StackLayout>
@@ -19,4 +20,4 @@
         </ScrollView>
     </StackLayout>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/PreferencesPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/PreferencesPage.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace Caboodle.Samples.View
 {
-    public partial class PreferencesPage : ContentPage
+    public partial class PreferencesPage : BasePage
     {
         public PreferencesPage()
         {

--- a/Samples/Caboodle.Samples/ViewModel/BaseViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/BaseViewModel.cs
@@ -1,33 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Text;
-
-namespace Caboodle.Samples.ViewModel
+﻿namespace Caboodle.Samples.ViewModel
 {
-    public class ObservableObject : INotifyPropertyChanged
-    {
-        protected virtual bool SetProperty<T>(ref T backingStore, T value, [CallerMemberName]string propertyName = "", Action onChanged = null, Func<T, T, bool> validateValue = null)
-        {
-            if (EqualityComparer<T>.Default.Equals(backingStore, value))
-                return false;
-
-            if (validateValue != null && !validateValue(backingStore, value))
-                return false;
-
-            backingStore = value;
-            onChanged?.Invoke();
-            OnPropertyChanged(propertyName);
-            return true;
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = "") =>
-         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-    }
-
     public class BaseViewModel : ObservableObject
     {
         bool isBusy;
@@ -35,23 +7,17 @@ namespace Caboodle.Samples.ViewModel
         public bool IsBusy
         {
             get => isBusy;
-            set
-            {
-                if (SetProperty(ref isBusy, value))
-                    IsNotBusy = !isBusy;
-            }
+            set => SetProperty(ref isBusy, value, onChanged: () => OnPropertyChanged(nameof(IsNotBusy)));
         }
 
-        bool isNotBusy = true;
+        public bool IsNotBusy => !IsBusy;
 
-        public bool IsNotBusy
+        public virtual void OnAppearing()
         {
-            get => isNotBusy;
-            set
-            {
-                if (SetProperty(ref isNotBusy, value))
-                    IsBusy = !isNotBusy;
-            }
+        }
+
+        public virtual void OnDisappearing()
+        {
         }
     }
 }

--- a/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
@@ -14,7 +14,21 @@ namespace Caboodle.Samples.ViewModel
 
         public BatteryPowerSource PowerSource => Battery.PowerSource;
 
-        public void Update(BatteryChangedEventArgs e)
+        public override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            Battery.BatteryChanged += OnBatteryChanged;
+        }
+
+        public override void OnDisappearing()
+        {
+            Battery.BatteryChanged -= OnBatteryChanged;
+
+            base.OnDisappearing();
+        }
+
+        void OnBatteryChanged(BatteryChangedEventArgs e)
         {
             OnPropertyChanged(nameof(Level));
             OnPropertyChanged(nameof(State));

--- a/Samples/Caboodle.Samples/ViewModel/DeviceInfoViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/DeviceInfoViewModel.cs
@@ -4,7 +4,7 @@ namespace Caboodle.Samples.ViewModel
 {
     public class DeviceInfoViewModel : BaseViewModel
     {
-        ScreenMetrics screenMetrics = DeviceInfo.ScreenMetrics;
+        ScreenMetrics screenMetrics;
 
         public DeviceInfoViewModel()
         {
@@ -36,6 +36,26 @@ namespace Caboodle.Samples.ViewModel
         {
             get => screenMetrics;
             set => SetProperty(ref screenMetrics, value);
+        }
+
+        public override async void OnAppearing()
+        {
+            base.OnAppearing();
+
+            DeviceInfo.ScreenMetricsChanaged += OnScreenMetricsChanged;
+            ScreenMetrics = await DeviceInfo.GetScreenMetricsAsync();
+        }
+
+        public override void OnDisappearing()
+        {
+            DeviceInfo.ScreenMetricsChanaged -= OnScreenMetricsChanged;
+
+            base.OnDisappearing();
+        }
+
+        void OnScreenMetricsChanged(ScreenMetricsChanagedEventArgs e)
+        {
+            ScreenMetrics = e.Metrics;
         }
     }
 }

--- a/Samples/Caboodle.Samples/ViewModel/ObservableObject.cs
+++ b/Samples/Caboodle.Samples/ViewModel/ObservableObject.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Caboodle.Samples.ViewModel
+{
+    public class ObservableObject : INotifyPropertyChanged
+    {
+        protected virtual bool SetProperty<T>(ref T backingStore, T value, [CallerMemberName]string propertyName = "", Action onChanged = null, Func<T, T, bool> validateValue = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(backingStore, value))
+                return false;
+
+            if (validateValue != null && !validateValue(backingStore, value))
+                return false;
+
+            backingStore = value;
+            onChanged?.Invoke();
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = "") =>
+         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}


### PR DESCRIPTION
Work to move thread switching into the library
 - no need to run on main thread for consumers

API changes
 - removed caching for device info

Sample improvements
 - samples now have improved view models for page events
 - pages now derive from BasePage which understands view models