### PR TITLE
GH-73: Add Battery Documentation

### DIFF
--- a/Caboodle/Battery/Battery.shared.cs
+++ b/Caboodle/Battery/Battery.shared.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Caboodle
 
     public class BatteryChangedEventArgs : EventArgs
     {
-        public BatteryChangedEventArgs(double level, BatteryState state, BatteryPowerSource source)
+        internal BatteryChangedEventArgs(double level, BatteryState state, BatteryPowerSource source)
         {
             ChargeLevel = level;
             State = state;

--- a/Samples/Caboodle.Samples/View/BatteryPage.xaml
+++ b/Samples/Caboodle.Samples/View/BatteryPage.xaml
@@ -13,10 +13,11 @@
 
         <ScrollView>
             <StackLayout Padding="12,0,12,12" Spacing="6">
-                <Label Text="Battery State:" FontAttributes="Bold" Margin="0,6,0,0" />
-                <Label Text="{Binding Level, StringFormat='Charge Level: {0:P1}'}"/>
-                <Label Text="{Binding State, StringFormat='State: {0}'}"/>
-                <Label Text="{Binding PowerSource, StringFormat='Power Source: {0}'}"/>
+                <Label Text="{Binding Level}"/>
+                <Label Text="{Binding State}"/>
+                <Label Text="{Binding PowerSource}"/>
+                <Button Text="Refresh Battery Stats" Command="{Binding RefreshStatsCommand}"/>
+                <Button Text="{Binding ListenText}" Command="{Binding ListenCommand}"/>
             </StackLayout>
         </ScrollView>
     </StackLayout>

--- a/Samples/Caboodle.Samples/View/BatteryPage.xaml
+++ b/Samples/Caboodle.Samples/View/BatteryPage.xaml
@@ -14,11 +14,10 @@
 
         <ScrollView>
             <StackLayout Padding="12,0,12,12" Spacing="6">
-                <Label Text="{Binding Level}"/>
-                <Label Text="{Binding State}"/>
-                <Label Text="{Binding PowerSource}"/>
-                <Button Text="Refresh Battery Stats" Command="{Binding RefreshStatsCommand}"/>
-                <Button Text="{Binding ListenText}" Command="{Binding ListenCommand}"/>
+                <Label Text="Battery State:" FontAttributes="Bold" Margin="0,6,0,0" />
+                <Label Text="{Binding Level, StringFormat='Charge Level: {0:P1}'}"/>
+                <Label Text="{Binding State, StringFormat='State: {0}'}"/>
+                <Label Text="{Binding PowerSource, StringFormat='Power Source: {0}'}"/>
             </StackLayout>
         </ScrollView>
     </StackLayout>

--- a/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Input;
-using Microsoft.Caboodle;
-using Xamarin.Forms;
+﻿using Microsoft.Caboodle;
 
 namespace Caboodle.Samples.ViewModel
 {

--- a/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
@@ -6,52 +6,15 @@ namespace Caboodle.Samples.ViewModel
 {
     public class BatteryViewModel : BaseViewModel
     {
-        public string Level => $"Charge Level: {Battery.ChargeLevel}";
-
-        public string State => $"State: {Battery.State}";
-
-        public string PowerSource => $"Power Source: {Battery.PowerSource}";
-
-        public string ListenText { get; set; } = "Listen for events";
-
-        public ICommand RefreshStatsCommand { get; }
-
-        public ICommand ListenCommand { get; }
-
-        bool listening;
-
         public BatteryViewModel()
         {
-            RefreshStatsCommand = new Command(() =>
-            {
-                OnPropertyChanged(nameof(Level));
-                OnPropertyChanged(nameof(State));
-                OnPropertyChanged(nameof(PowerSource));
-            });
-
-            ListenCommand = new Command(() =>
-            {
-                if (!listening)
-                {
-                    Battery.BatteryChanged += Battery_BatteryChanged;
-                    ListenText = "Stop listening";
-                }
-                else
-                {
-                    Battery.BatteryChanged -= Battery_BatteryChanged;
-                    ListenText = "Listen for events";
-                }
-
-                listening = !listening;
-                OnPropertyChanged(nameof(ListenText));
-            });
         }
 
-        async void Battery_BatteryChanged(BatteryChangedEventArgs e)
-        {
-            RefreshStatsCommand.Execute(null);
-            await Application.Current.MainPage.DisplayAlert("Battery Event", $"Battery status changes\n Level: {e.ChargeLevel}\n Source: {e.PowerSource}\n State: {e.State}", "OK");
-        }
+        public double Level => Battery.ChargeLevel;
+
+        public BatteryState State => Battery.State;
+
+        public BatteryPowerSource PowerSource => Battery.PowerSource;
 
         public override void OnAppearing()
         {
@@ -69,10 +32,9 @@ namespace Caboodle.Samples.ViewModel
 
         void OnBatteryChanged(BatteryChangedEventArgs e)
         {
-            if (listening)
-            {
-                Battery.BatteryChanged -= Battery_BatteryChanged;
-            }
+            OnPropertyChanged(nameof(Level));
+            OnPropertyChanged(nameof(State));
+            OnPropertyChanged(nameof(PowerSource));
         }
     }
 }

--- a/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/BatteryViewModel.cs
@@ -1,24 +1,64 @@
-﻿using Microsoft.Caboodle;
+﻿using System.Windows.Input;
+using Microsoft.Caboodle;
+using Xamarin.Forms;
 
 namespace Caboodle.Samples.ViewModel
 {
     public class BatteryViewModel : BaseViewModel
     {
+        public string Level => $"Charge Level: {Battery.ChargeLevel}";
+
+        public string State => $"State: {Battery.State}";
+
+        public string PowerSource => $"Power Source: {Battery.PowerSource}";
+
+        public string ListenText { get; set; } = "Listen for events";
+
+        public ICommand RefreshStatsCommand { get; }
+
+        public ICommand ListenCommand { get; }
+
+        bool listening;
+
         public BatteryViewModel()
         {
+            RefreshStatsCommand = new Command(() =>
+            {
+                OnPropertyChanged(nameof(Level));
+                OnPropertyChanged(nameof(State));
+                OnPropertyChanged(nameof(PowerSource));
+            });
+
+            ListenCommand = new Command(() =>
+            {
+                if (!listening)
+                {
+                    Battery.BatteryChanged += Battery_BatteryChanged;
+                    ListenText = "Stop listening";
+                }
+                else
+                {
+                    Battery.BatteryChanged -= Battery_BatteryChanged;
+                    ListenText = "Listen for events";
+                }
+
+                listening = !listening;
+                OnPropertyChanged(nameof(ListenText));
+            });
         }
 
-        public double Level => Battery.ChargeLevel;
-
-        public BatteryState State => Battery.State;
-
-        public BatteryPowerSource PowerSource => Battery.PowerSource;
-
-        public void Update(BatteryChangedEventArgs e)
+        async void Battery_BatteryChanged(BatteryChangedEventArgs e)
         {
-            OnPropertyChanged(nameof(Level));
-            OnPropertyChanged(nameof(State));
-            OnPropertyChanged(nameof(PowerSource));
+            RefreshStatsCommand.Execute(null);
+            await Application.Current.MainPage.DisplayAlert("Battery Event", $"Battery status changes\n Level: {e.ChargeLevel}\n Source: {e.PowerSource}\n State: {e.State}", "OK");
+        }
+
+        public void Stop()
+        {
+            if (listening)
+            {
+                Battery.BatteryChanged -= Battery_BatteryChanged;
+            }
         }
     }
 }

--- a/docs/en/Microsoft.Caboodle/Battery.xml
+++ b/docs/en/Microsoft.Caboodle/Battery.xml
@@ -1,0 +1,99 @@
+<Type Name="Battery" FullName="Microsoft.Caboodle.Battery">
+  <TypeSignature Language="C#" Value="public static class Battery" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Battery extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Methods and properties for battery and charging information of the device.</summary>
+    <remarks>
+      <para>Platform specific remarks:</para>
+      <para>- Android: Battery_Stats permission must be set in manifest.</para>
+      <para>- iOS: Simulator will not return battery information, must be run on device</para>
+      <para>- UWP: None</para>
+      <para></para>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="BatteryChanged">
+      <MemberSignature Language="C#" Value="public static event Microsoft.Caboodle.BatteryChangedEventHandler BatteryChanged;" />
+      <MemberSignature Language="ILAsm" Value=".event class Microsoft.Caboodle.BatteryChangedEventHandler BatteryChanged" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryChangedEventHandler</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Event trigger when battery properties have changed.</summary>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ChargeLevel">
+      <MemberSignature Language="C#" Value="public static double ChargeLevel { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property float64 ChargeLevel" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the current charge level of the device from 0.0 to 1.0.</summary>
+        <value>
+          <para>Level of charge.</para>
+        </value>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PowerSource">
+      <MemberSignature Language="C#" Value="public static Microsoft.Caboodle.BatteryPowerSource PowerSource { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property valuetype Microsoft.Caboodle.BatteryPowerSource PowerSource" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the current power source for the device.</summary>
+        <value>
+          <para>Power source, or uknown.</para>
+        </value>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="State">
+      <MemberSignature Language="C#" Value="public static Microsoft.Caboodle.BatteryState State { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property valuetype Microsoft.Caboodle.BatteryState State" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the charging state of the device if it can be determined.</summary>
+        <value>Battery state, or unknown.</value>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Microsoft.Caboodle/BatteryChangedEventArgs.xml
+++ b/docs/en/Microsoft.Caboodle/BatteryChangedEventArgs.xml
@@ -1,0 +1,72 @@
+<Type Name="BatteryChangedEventArgs" FullName="Microsoft.Caboodle.BatteryChangedEventArgs">
+  <TypeSignature Language="C#" Value="public class BatteryChangedEventArgs : EventArgs" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit BatteryChangedEventArgs extends System.EventArgs" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.EventArgs</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Battery changed information.</summary>
+    <remarks>Returns the current information of the battery.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="ChargeLevel">
+      <MemberSignature Language="C#" Value="public double ChargeLevel { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 ChargeLevel" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the current charge level of the device from 0.0 to 1.0.</summary>
+        <value>Level of charge.</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PowerSource">
+      <MemberSignature Language="C#" Value="public Microsoft.Caboodle.BatteryPowerSource PowerSource { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Microsoft.Caboodle.BatteryPowerSource PowerSource" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the current power source for the device.</summary>
+        <value>Power source, or unknown</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="State">
+      <MemberSignature Language="C#" Value="public Microsoft.Caboodle.BatteryState State { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Microsoft.Caboodle.BatteryState State" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the charging state of the device if it can be determined.</summary>
+        <value>Battery state, or unknown.</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Microsoft.Caboodle/BatteryChangedEventHandler.xml
+++ b/docs/en/Microsoft.Caboodle/BatteryChangedEventHandler.xml
@@ -1,0 +1,24 @@
+<Type Name="BatteryChangedEventHandler" FullName="Microsoft.Caboodle.BatteryChangedEventHandler">
+  <TypeSignature Language="C#" Value="public delegate void BatteryChangedEventHandler(BatteryChangedEventArgs e);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed BatteryChangedEventHandler extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="e" Type="Microsoft.Caboodle.BatteryChangedEventArgs" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="e">BatteryChangeEventArgs with new information.</param>
+    <summary>Event handler that is triggered when the battery changes.</summary>
+    <remarks>
+      <para />
+    </remarks>
+  </Docs>
+</Type>

--- a/docs/en/Microsoft.Caboodle/BatteryPowerSource.xml
+++ b/docs/en/Microsoft.Caboodle/BatteryPowerSource.xml
@@ -1,0 +1,94 @@
+<Type Name="BatteryPowerSource" FullName="Microsoft.Caboodle.BatteryPowerSource">
+  <TypeSignature Language="C#" Value="public enum BatteryPowerSource" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed BatteryPowerSource extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>How the device and battery are currently being powered or charged.</summary>
+    <remarks>
+      <para></para>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Ac">
+      <MemberSignature Language="C#" Value="Ac" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryPowerSource Ac = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <MemberValue>2</MemberValue>
+      <Docs>
+        <summary>Power source is an AC Charger.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Battery">
+      <MemberSignature Language="C#" Value="Battery" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryPowerSource Battery = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <MemberValue>1</MemberValue>
+      <Docs>
+        <summary>Power source is the battery and not being charge.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Unknown">
+      <MemberSignature Language="C#" Value="Unknown" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryPowerSource Unknown = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Docs>
+        <summary>Power source can not be determined.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Usb">
+      <MemberSignature Language="C#" Value="Usb" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryPowerSource Usb = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <MemberValue>3</MemberValue>
+      <Docs>
+        <summary>Power source is a USB port.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Wireless">
+      <MemberSignature Language="C#" Value="Wireless" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryPowerSource Wireless = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryPowerSource</ReturnType>
+      </ReturnValue>
+      <MemberValue>4</MemberValue>
+      <Docs>
+        <summary>Power source is wireless.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Microsoft.Caboodle/BatteryState.xml
+++ b/docs/en/Microsoft.Caboodle/BatteryState.xml
@@ -1,0 +1,94 @@
+<Type Name="BatteryState" FullName="Microsoft.Caboodle.BatteryState">
+  <TypeSignature Language="C#" Value="public enum BatteryState" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed BatteryState extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>The current state of the battery and if it is being charged or full.</summary>
+    <remarks>
+      <para></para>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Charging">
+      <MemberSignature Language="C#" Value="Charging" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryState Charging = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>1</MemberValue>
+      <Docs>
+        <summary>Battery is acively being charged by a power source.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Discharging">
+      <MemberSignature Language="C#" Value="Discharging" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryState Discharging = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>2</MemberValue>
+      <Docs>
+        <summary>Battery is not plugged in and discharging.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Full">
+      <MemberSignature Language="C#" Value="Full" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryState Full = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>3</MemberValue>
+      <Docs>
+        <summary>Battery is full.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="NotCharging">
+      <MemberSignature Language="C#" Value="NotCharging" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryState NotCharging = int32(4)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>4</MemberValue>
+      <Docs>
+        <summary>Battery is not charging or discharging, but in an inbetween state.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Unknown">
+      <MemberSignature Language="C#" Value="Unknown" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Caboodle.BatteryState Unknown = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Caboodle.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Docs>
+        <summary>Battery state could not be determined.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
### Description of Change ###

Add documentation for battery API for #73 


### API Changes ###

Changed:

 - made the constructor of event args internal.

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
