### PR TITLE
Remove unnecessary MSBuilld snippets that already ship with XF

### DIFF
--- a/Samples/Caboodle.Samples/Caboodle.Samples.csproj
+++ b/Samples/Caboodle.Samples/Caboodle.Samples.csproj
@@ -20,18 +20,6 @@
     <ProjectReference Include="..\..\Caboodle\Caboodle.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Condition=" '$(EnableDefaultCompileItems)' == 'true' " Update="App.xaml.cs">
-      <DependentUpon>*.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="**\*.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 
 </Project>


### PR DESCRIPTION
The referenced version of XF already provides targets for both removed snippets, see 
https://github.com/xamarin/Xamarin.Forms/blob/2.5.0/.nuspec/Xamarin.Forms.DefaultItems.targets#L11 and 
https://github.com/xamarin/Xamarin.Forms/blob/2.5.0/.nuspec/Xamarin.Forms.DefaultItems.props#L4.
