### PR TITLE
Make Geocoding testable from desktop unit test projects

### DIFF
--- a/Caboodle.sln
+++ b/Caboodle.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caboodle.DeviceTests.iOS", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caboodle.DeviceTests.UWP", "DeviceTests\Caboodle.DeviceTests.UWP\Caboodle.DeviceTests.UWP.csproj", "{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Caboodle.Samples.Tests", "Samples\Caboodle.Samples.Tests\Caboodle.Samples.Tests.csproj", "{ADFA598A-957E-4D3F-BD79-E75F3400D52D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		DeviceTests\Caboodle.DeviceTests.Shared\Caboodle.DeviceTests.Shared.projitems*{4bd0d88f-7e7a-4c3b-9e34-bf3717a8ff4b}*SharedItemsImports = 4
@@ -322,6 +324,30 @@ Global
 		{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B}.Release|x86.ActiveCfg = Release|x86
 		{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B}.Release|x86.Build.0 = Release|x86
 		{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B}.Release|x86.Deploy.0 = Release|x86
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|ARM.Build.0 = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|iPhone.Build.0 = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|x64.Build.0 = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -337,6 +363,7 @@ Global
 		{CB2072E0-A437-4811-AE17-16CAE0DDA1B1} = {EA9AC363-45BC-4959-BD17-FE3A1B724529}
 		{EE8FC716-27FC-405B-BD27-AF17E01A6671} = {EA9AC363-45BC-4959-BD17-FE3A1B724529}
 		{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B} = {EA9AC363-45BC-4959-BD17-FE3A1B724529}
+		{ADFA598A-957E-4D3F-BD79-E75F3400D52D} = {706C0487-6930-4E55-8720-C17D9FE6CA91}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {105B0052-C7EA-44D0-8697-37A45E1392AF}

--- a/Caboodle/Caboodle.csproj
+++ b/Caboodle/Caboodle.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <!--Work around so the conditions work below-->
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net461;Xamarin.iOS10;MonoAndroid80;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;net461;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
     <AssemblyName>Microsoft.Caboodle</AssemblyName>
     <RootNamespace>Microsoft.Caboodle</RootNamespace>
     <PackageId>Microsoft.Caboodle</PackageId>
@@ -42,7 +42,11 @@
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.5.0" PrivateAssets="All" />
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2.0" PrivateAssets="All" />
+
     <Compile Include="**\*.shared.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <Compile Include="**\*.net.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="**\*.netstandard.cs" />

--- a/Caboodle/Geocoding/Geocoding.netstandard.cs
+++ b/Caboodle/Geocoding/Geocoding.netstandard.cs
@@ -1,11 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Caboodle
 {
     public partial class Geocoding
     {
-        public static IGeocoding Current { get; set; }
+        static AsyncLocal<IGeocoding> current;
+
+        public static IGeocoding Current
+        {
+            get => current.Value;
+            set => current.Value = value;
+        }
 
         public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude) =>
             Current?.GetPlacemarksAsync(latitude, longitude) ?? throw new NotImplentedInReferenceAssembly();

--- a/Caboodle/Geocoding/Geocoding.netstandard.cs
+++ b/Caboodle/Geocoding/Geocoding.netstandard.cs
@@ -5,10 +5,19 @@ namespace Microsoft.Caboodle
 {
     public partial class Geocoding
     {
+        public static IGeocoding Current { get; set; }
+
         public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude) =>
-            throw new NotImplentedInReferenceAssembly();
+            Current?.GetPlacemarksAsync(latitude, longitude) ?? throw new NotImplentedInReferenceAssembly();
 
         public static Task<IEnumerable<Location>> GetLocationsAsync(string address) =>
-            throw new NotImplentedInReferenceAssembly();
+            Current?.GetLocationsAsync(address) ?? throw new NotImplentedInReferenceAssembly();
+    }
+
+    public interface IGeocoding
+    {
+        Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude);
+
+        Task<IEnumerable<Location>> GetLocationsAsync(string address);
     }
 }

--- a/Samples/Caboodle.Samples.Tests/Caboodle.Samples.Tests.csproj
+++ b/Samples/Caboodle.Samples.Tests/Caboodle.Samples.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Caboodle.Samples\Caboodle.Samples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/Caboodle.Samples.Tests/GeocodingViewModel_Tests.cs
+++ b/Samples/Caboodle.Samples.Tests/GeocodingViewModel_Tests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Caboodle.Samples.ViewModel;
+using Microsoft.Caboodle;
+using Moq;
+using Xunit;
+
+namespace Caboodle.Samples.Tests
+{
+    public class GeocodingViewModel_Tests
+    {
+        [Fact]
+        public void Get_Address()
+        {
+            Geocoding.Current = Mock.Of<IGeocoding>();
+
+            Mock.Get(Geocoding.Current)
+                .Setup(x => x.GetPlacemarksAsync(10, 20))
+                .ReturnsAsync(new Placemark[] { new Placemark { FeatureName = "Test" } });
+
+            var viewModel = new GeocodingViewModel();
+
+            viewModel.Latitude = "10";
+            viewModel.Longitude = "20";
+
+            viewModel.GetAddressCommand.Execute(null);
+
+            Assert.NotNull(viewModel.GeocodeAddress);
+            Assert.Contains("FeatureName: Test", viewModel.GeocodeAddress);
+        }
+    }
+}


### PR DESCRIPTION
This showcases how a minimal change in the netstandard version of the
API can trivially allow for fully testable API invocations without
incurring in *any* of the run-time performance compromises of switching
the platform implementations to use either unnecessary interface/virtual
calls or even instance method call overhead ('cause of the null reference
check that's otherwise not necessary).

This is an effective compromise that covers the majority of the testing
scenarios (unit testing from view models down) while still preserving
the desired run-time characteristics of the project.

### Description of Change ###

Tweak *just* the netstandard version of an API to make it trivially 
testable from desktop unit tests.

### Bugs Fixed ###

The overwhelming feedback that un-testable APIs are not cool ;)

Also, my personal belief that forcing everyone to invent their own 
abstractions and achieving the same through unnecessary indirections  
that *do* impact ultimate run-time performance is bad for both 
our users (developers) as well as their customers (users of their apps).

### API Changes ###

Added: 
 
- IGeocoding (as an example only, it's not strictly required), *only* to the 
  netstandard Geocoding 
- Geocoding.Current, to allow replacing the implementation with a fake/mock

### Behavioral Changes ###

No behavioral changes whatsoever are introduced in the platform code. The 
netstandard code passes all existing unit tests too, since by default it will still 
throw the same exception as before, unless a test overrides the implementation.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
