### PR TITLE
Minor text fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you're looking for something to fix, please browse [open issues](https://gith
 Follow the style used by the [.NET Foundation](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md), with two primary exceptions:
 
 - We do not use the `private` keyword as it is the default accessibility level in C#.
-- We will **not** use `_` or `_s` as a prefix for internal or private field names
+- We will **not** use `_` or `s_` as a prefix for internal or private field names
 - We will use `camelCaseFieldName` for naming internal or private fields in both instance and static implementations
 
 Read and follow our [Pull Request template](https://github.com/xamarin/Caboodle/blob/master/PULL_REQUEST_TEMPLATE.md)


### PR DESCRIPTION
### Description of Change ###

changed `_s` to `s_`

From [C# Coding Style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md):
>We use \_camelCase for internal and private fields and use readonly where possible. Prefix instance fields with \_, static fields with s\_ and thread static fields with t\_. When used on static fields, readonly should come after static (i.e. static readonly not readonly static).