### PR TITLE
GH-82: Fix type and add Exception for NotImplementedInReference

### DIFF
--- a/Caboodle.Tests/Battery_Tests.cs
+++ b/Caboodle.Tests/Battery_Tests.cs
@@ -7,19 +7,19 @@ namespace Caboodle.Tests
     {
         [Fact]
         public void Charge_Level_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Battery.ChargeLevel);
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Battery.ChargeLevel);
 
         [Fact]
         public void Charge_State_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Battery.State);
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Battery.State);
 
         [Fact]
         public void Charge_Power_Source_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Battery.PowerSource);
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Battery.PowerSource);
 
         [Fact]
         public void Battery_Changed_Event_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Battery.BatteryChanged += Battery_BatteryChanged);
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Battery.BatteryChanged += Battery_BatteryChanged);
 
         void Battery_BatteryChanged(BatteryChangedEventArgs e)
         {

--- a/Caboodle.Tests/Clipboard_Tests.cs
+++ b/Caboodle.Tests/Clipboard_Tests.cs
@@ -9,19 +9,19 @@ namespace Caboodle.Tests
         [Fact]
         public void Clipboard_SetText_Fail_On_NetStandard()
         {
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Clipboard.SetText("Text"));
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Clipboard.SetText("Text"));
         }
 
         [Fact]
         public void Clipboard_HasText_Fail_On_NetStandard()
         {
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => Clipboard.HasText);
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Clipboard.HasText);
         }
 
         [Fact]
         public async Task Clipboard_GetText_Fail_On_NetStandard()
         {
-            await Assert.ThrowsAsync<NotImplentedInReferenceAssembly>(() => Clipboard.GetTextAsync());
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Clipboard.GetTextAsync());
         }
     }
 }

--- a/Caboodle.Tests/Geocoding_Tests.cs
+++ b/Caboodle.Tests/Geocoding_Tests.cs
@@ -9,19 +9,19 @@ namespace Caboodle.Tests
         [Fact]
         public async Task Geocoding_Placemarks_Fail_On_NetStandard()
         {
-            await Assert.ThrowsAsync<NotImplentedInReferenceAssembly>(() => Geocoding.GetPlacemarksAsync(1, 1));
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Geocoding.GetPlacemarksAsync(1, 1));
         }
 
         [Fact]
         public async Task Geocoding_Placemarks_Location_Fail_On_NetStandard()
         {
-            await Assert.ThrowsAsync<NotImplentedInReferenceAssembly>(() => Geocoding.GetPlacemarksAsync(new Location(1, 1)));
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Geocoding.GetPlacemarksAsync(new Location(1, 1)));
         }
 
         [Fact]
         public async Task Geocoding_Locations_On_NetStandard()
         {
-            await Assert.ThrowsAsync<NotImplentedInReferenceAssembly>(() => Geocoding.GetLocationsAsync("Microsoft Building 25"));
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Geocoding.GetLocationsAsync("Microsoft Building 25"));
         }
     }
 }

--- a/Caboodle.Tests/Preferences_Tests.cs
+++ b/Caboodle.Tests/Preferences_Tests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Caboodle.Tests
         public void Preferences_Fail_On_NetStandard()
         {
             var p = new Preferences();
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => p.Set("anything", "fails"));
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => p.Set("anything", "fails"));
         }
     }
 }

--- a/Caboodle/Battery/Battery.netstandard.cs
+++ b/Caboodle/Battery/Battery.netstandard.cs
@@ -3,18 +3,18 @@
     public static partial class Battery
     {
         static void StartBatteryListeners() =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         static void StopBatteryListeners() =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public static double ChargeLevel =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public static BatteryState State =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public static BatteryPowerSource PowerSource =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/Clipboard/Clipboard.netstandard.cs
+++ b/Caboodle/Clipboard/Clipboard.netstandard.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Caboodle
     public static partial class Clipboard
     {
         public static void SetText(string text)
-            => throw new NotImplentedInReferenceAssembly();
+            => throw new NotImplementedInReferenceAssemblyException();
 
         public static bool HasText
-            => throw new NotImplentedInReferenceAssembly();
+            => throw new NotImplementedInReferenceAssemblyException();
 
         public static Task<string> GetTextAsync()
-            => throw new NotImplentedInReferenceAssembly();
+            => throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
@@ -4,32 +4,32 @@ namespace Microsoft.Caboodle
 {
     public static partial class DeviceInfo
     {
-        static string GetModel() => throw new NotImplentedInReferenceAssembly();
+        static string GetModel() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetManufacturer() => throw new NotImplentedInReferenceAssembly();
+        static string GetManufacturer() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetDeviceName() => throw new NotImplentedInReferenceAssembly();
+        static string GetDeviceName() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetVersionString() => throw new NotImplentedInReferenceAssembly();
+        static string GetVersionString() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetAppPackageName() => throw new NotImplentedInReferenceAssembly();
+        static string GetAppPackageName() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetAppName() => throw new NotImplentedInReferenceAssembly();
+        static string GetAppName() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetAppVersionString() => throw new NotImplentedInReferenceAssembly();
+        static string GetAppVersionString() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetAppBuild() => throw new NotImplentedInReferenceAssembly();
+        static string GetAppBuild() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetPlatform() => throw new NotImplentedInReferenceAssembly();
+        static string GetPlatform() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetIdiom() => throw new NotImplentedInReferenceAssembly();
+        static string GetIdiom() => throw new NotImplementedInReferenceAssemblyException();
 
-        static DeviceType GetDeviceType() => throw new NotImplentedInReferenceAssembly();
+        static DeviceType GetDeviceType() => throw new NotImplementedInReferenceAssemblyException();
 
-        static ScreenMetrics GetScreenMetrics() => throw new NotImplentedInReferenceAssembly();
+        static ScreenMetrics GetScreenMetrics() => throw new NotImplementedInReferenceAssemblyException();
 
-        static void StartScreenMetricsListeners() => throw new NotImplentedInReferenceAssembly();
+        static void StartScreenMetricsListeners() => throw new NotImplementedInReferenceAssemblyException();
 
-        static void StopScreenMetricsListeners() => throw new NotImplentedInReferenceAssembly();
+        static void StopScreenMetricsListeners() => throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/Geocoding/Geocoding.netstandard.cs
+++ b/Caboodle/Geocoding/Geocoding.netstandard.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Caboodle
     public static partial class Geocoding
     {
         public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public static Task<IEnumerable<Location>> GetLocationsAsync(string address) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/Platform/Platform.netstandard.cs
+++ b/Caboodle/Platform/Platform.netstandard.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Caboodle
     public static partial class Platform
     {
         public static void BeginInvokeOnMainThread(Action action) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/Preferences/Preferences.netstandard.cs
+++ b/Caboodle/Preferences/Preferences.netstandard.cs
@@ -7,18 +7,18 @@ namespace Microsoft.Caboodle
     public partial class Preferences
     {
         public bool ContainsKey(string key) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public void Remove(string key) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public void Clear() =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         void Set<T>(string key, T value) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         T Get<T>(string key, T defaultValue) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/Shared/Exceptions.shared.cs
+++ b/Caboodle/Shared/Exceptions.shared.cs
@@ -2,9 +2,9 @@
 
 namespace Microsoft.Caboodle
 {
-    public class NotImplentedInReferenceAssembly : NotImplementedException
+    public class NotImplementedInReferenceAssemblyException : NotImplementedException
     {
-        public NotImplentedInReferenceAssembly()
+        public NotImplementedInReferenceAssemblyException()
             : base("This functionality is not implemented in the portable version of this assembly.  You should reference the NuGet package from your main application project in order to reference the platform-specific implementation.")
         {
         }


### PR DESCRIPTION
### Description of Change ###

Fix big glaring type and add exception at the end

### Bugs Fixed ###

- Related to issue #82 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

Changed to: NotImplementedInReferenceAssemblyException


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
