### PR TITLE
GH-88 Fix for UWP battery when fully charged

### DIFF
--- a/Caboodle/Battery/Battery.uwp.cs
+++ b/Caboodle/Battery/Battery.uwp.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Caboodle
                     case Windows.System.Power.BatteryStatus.Discharging:
                         return BatteryState.Discharging;
                     case Windows.System.Power.BatteryStatus.Idle:
+                        if (ChargeLevel >= 1.0)
+                            return BatteryState.Full;
                         return BatteryState.NotCharging;
                     case Windows.System.Power.BatteryStatus.NotPresent:
                         return BatteryState.Unknown;
@@ -67,6 +69,9 @@ namespace Microsoft.Caboodle
                 var currentStatus = State;
                 if (currentStatus == BatteryState.Full || currentStatus == BatteryState.Charging)
                     return BatteryPowerSource.Ac;
+
+                if (currentStatus == BatteryState.Unknown)
+                    return BatteryPowerSource.Unknown;
 
                 return BatteryPowerSource.Battery;
             }


### PR DESCRIPTION
### Description of Change ###

Proper checks for when battery is full on UWP.

### Bugs Fixed ###

- Related to issue #88

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

Add checks for full when battery is Idle

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
