### PR TITLE
GH-22: Initial Support for Data Transfer aka Share

### DIFF
--- a/Caboodle.Tests/DataTransfer_Tests.cs
+++ b/Caboodle.Tests/DataTransfer_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Caboodle;
+﻿using System.Threading.Tasks;
+using Microsoft.Caboodle;
 using Xunit;
 
 namespace Caboodle.Tests
@@ -6,15 +7,15 @@ namespace Caboodle.Tests
     public class DataTransfer_Tests
     {
         [Fact]
-        public async System.Threading.Tasks.Task Show_Share_UI_Text_NetStandard() =>
-            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI("Text"));
+        public async Task Request_Text_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.RequestAsync("Text"));
 
         [Fact]
-        public async System.Threading.Tasks.Task Show_Share_UI_Text_Title_NetStandard() =>
-            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI("Text", "Title"));
+        public async Task Request_Text_Title_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.RequestAsync("Text", "Title"));
 
         [Fact]
-        public async System.Threading.Tasks.Task Show_Share_UI_Request_NetStandard() =>
-            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI(new ShareTextRequest()));
+        public async Task Request_Text_Request_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.RequestAsync(new ShareTextRequest()));
     }
 }

--- a/Caboodle.Tests/DataTransfer_Tests.cs
+++ b/Caboodle.Tests/DataTransfer_Tests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Caboodle;
+using Xunit;
+
+namespace Caboodle.Tests
+{
+    public class DataTransfer_Tests
+    {
+        [Fact]
+        public async System.Threading.Tasks.Task Show_Share_UI_Text_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI("Text"));
+
+        [Fact]
+        public async System.Threading.Tasks.Task Show_Share_UI_Text_Title_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI("Text", "Title"));
+
+        [Fact]
+        public async System.Threading.Tasks.Task Show_Share_UI_Request_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => DataTransfer.ShowShareUI(new ShareTextRequest()));
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.android.cs
+++ b/Caboodle/DataTransfer/DataTransfer.android.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Caboodle
 {
     public static partial class DataTransfer
     {
-        public static Task ShowShareUI(ShareTextRequest request)
+        public static Task RequestAsync(ShareTextRequest request)
         {
             var items = new List<string>();
             if (!string.IsNullOrWhiteSpace(request.Text))

--- a/Caboodle/DataTransfer/DataTransfer.android.cs
+++ b/Caboodle/DataTransfer/DataTransfer.android.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Android.Content;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class DataTransfer
+    {
+        public static Task ShowShareUI(ShareTextRequest request)
+        {
+            var items = new List<string>();
+            if (!string.IsNullOrWhiteSpace(request.Text))
+            {
+                items.Add(request.Text);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Uri))
+            {
+                items.Add(request.Uri);
+            }
+
+            var intent = new Intent(Intent.ActionSend);
+            intent.SetType("text/plain");
+            intent.PutExtra(Intent.ExtraText, string.Join(Environment.NewLine, items));
+
+            if (!string.IsNullOrWhiteSpace(request.Subject))
+            {
+                intent.PutExtra(Intent.ExtraSubject, request.Subject);
+            }
+
+            var chooserIntent = Intent.CreateChooser(intent, request.Title ?? string.Empty);
+            chooserIntent.SetFlags(ActivityFlags.ClearTop);
+            chooserIntent.SetFlags(ActivityFlags.NewTask);
+            Platform.CurrentContext.StartActivity(chooserIntent);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.ios.cs
+++ b/Caboodle/DataTransfer/DataTransfer.ios.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Caboodle
 {
     public static partial class DataTransfer
     {
-        public static Task ShowShareUI(ShareTextRequest request)
+        public static Task RequestAsync(ShareTextRequest request)
         {
             var items = new List<NSObject>();
             if (!string.IsNullOrWhiteSpace(request.Text))

--- a/Caboodle/DataTransfer/DataTransfer.ios.cs
+++ b/Caboodle/DataTransfer/DataTransfer.ios.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class DataTransfer
+    {
+        public static Task ShowShareUI(ShareTextRequest request)
+        {
+            var items = new List<NSObject>();
+            if (!string.IsNullOrWhiteSpace(request.Text))
+            {
+                items.Add(new ShareActivityItemSource(new NSString(request.Text), request.Title));
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Uri))
+            {
+                items.Add(new ShareActivityItemSource(NSUrl.FromString(request.Uri), request.Title));
+            }
+
+            var activityController = new UIActivityViewController(items.ToArray(), null);
+
+            var vc = Platform.GetCurrentViewController();
+
+            if (activityController.PopoverPresentationController != null)
+            {
+                activityController.PopoverPresentationController.SourceView = vc.View;
+            }
+
+            return vc.PresentViewControllerAsync(activityController, true);
+        }
+
+        internal class ShareActivityItemSource : UIActivityItemSource
+        {
+            NSObject item;
+            string subject;
+
+            public ShareActivityItemSource(NSObject item, string subject)
+            {
+                this.item = item;
+                this.subject = subject;
+            }
+
+            public override NSObject GetItemForActivity(UIActivityViewController activityViewController, NSString activityType) => item;
+
+            public override NSObject GetPlaceholderData(UIActivityViewController activityViewController) => item;
+
+            public override string GetSubjectForActivity(UIActivityViewController activityViewController, NSString activityType) => subject;
+        }
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.netstandard.cs
+++ b/Caboodle/DataTransfer/DataTransfer.netstandard.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class DataTransfer
+    {
+        public static Task ShowShareUI(ShareTextRequest request) =>
+            throw new NotImplementedInReferenceAssemblyException();
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.netstandard.cs
+++ b/Caboodle/DataTransfer/DataTransfer.netstandard.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Caboodle
 {
     public static partial class DataTransfer
     {
-        public static Task ShowShareUI(ShareTextRequest request) =>
+        public static Task RequestAsync(ShareTextRequest request) =>
             throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/DataTransfer/DataTransfer.shared.cs
+++ b/Caboodle/DataTransfer/DataTransfer.shared.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class DataTransfer
+    {
+        public static Task ShowShareUI(string text) =>
+            ShowShareUI(new ShareTextRequest { Text = text });
+
+        public static Task ShowShareUI(string text, string title) =>
+            ShowShareUI(new ShareTextRequest { Text = text, Title = title });
+    }
+
+    public class ShareTextRequest
+    {
+        public string Title { get; set; }
+
+        public string Subject { get; set; }
+
+        public string Text { get; set; }
+
+        public string Uri { get; set; }
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.shared.cs
+++ b/Caboodle/DataTransfer/DataTransfer.shared.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Caboodle
 {
     public static partial class DataTransfer
     {
-        public static Task ShowShareUI(string text) =>
-            ShowShareUI(new ShareTextRequest(text));
+        public static Task RequestAsync(string text) =>
+            RequestAsync(new ShareTextRequest(text));
 
-        public static Task ShowShareUI(string text, string title) =>
-            ShowShareUI(new ShareTextRequest(text, title));
+        public static Task RequestAsync(string text, string title) =>
+            RequestAsync(new ShareTextRequest(text, title));
     }
 
     public class ShareTextRequest

--- a/Caboodle/DataTransfer/DataTransfer.shared.cs
+++ b/Caboodle/DataTransfer/DataTransfer.shared.cs
@@ -8,14 +8,23 @@ namespace Microsoft.Caboodle
     public static partial class DataTransfer
     {
         public static Task ShowShareUI(string text) =>
-            ShowShareUI(new ShareTextRequest { Text = text });
+            ShowShareUI(new ShareTextRequest(text));
 
         public static Task ShowShareUI(string text, string title) =>
-            ShowShareUI(new ShareTextRequest { Text = text, Title = title });
+            ShowShareUI(new ShareTextRequest(text, title));
     }
 
     public class ShareTextRequest
     {
+        public ShareTextRequest()
+        {
+        }
+
+        public ShareTextRequest(string text) => Text = text;
+
+        public ShareTextRequest(string text, string title)
+            : this(text) => Title = title;
+
         public string Title { get; set; }
 
         public string Subject { get; set; }

--- a/Caboodle/DataTransfer/DataTransfer.uwp.cs
+++ b/Caboodle/DataTransfer/DataTransfer.uwp.cs
@@ -9,38 +9,32 @@ namespace Microsoft.Caboodle
 {
     public static partial class DataTransfer
     {
-        static ShareTextRequest shareRequest;
-
-        public static Task ShowShareUI(ShareTextRequest request)
+        public static Task RequestAsync(ShareTextRequest request)
         {
-            shareRequest = request;
-
             var dataTransferManager = DataTransferManager.GetForCurrentView();
 
             dataTransferManager.DataRequested += new TypedEventHandler<DataTransferManager, DataRequestedEventArgs>(ShareTextHandler);
 
             DataTransferManager.ShowShareUI();
 
+            void ShareTextHandler(DataTransferManager sender, DataRequestedEventArgs e)
+            {
+                var newRequest = e.Request;
+
+                newRequest.Data.Properties.Title = request.Title ?? DeviceInfo.AppName;
+
+                if (!string.IsNullOrWhiteSpace(request.Text))
+                {
+                    newRequest.Data.SetText(request.Text);
+                }
+
+                if (!string.IsNullOrWhiteSpace(request.Uri))
+                {
+                    newRequest.Data.SetWebLink(new Uri(request.Uri));
+                }
+            }
+
             return Task.CompletedTask;
-        }
-
-        static void ShareTextHandler(DataTransferManager sender, DataRequestedEventArgs e)
-        {
-            var request = e.Request;
-
-            request.Data.Properties.Title = shareRequest.Title ?? DeviceInfo.AppName;
-
-            if (!string.IsNullOrWhiteSpace(shareRequest.Text))
-            {
-                request.Data.SetText(shareRequest.Text);
-            }
-
-            if (!string.IsNullOrWhiteSpace(shareRequest.Uri))
-            {
-                request.Data.SetWebLink(new Uri(shareRequest.Uri));
-            }
-
-            shareRequest = null;
         }
     }
 }

--- a/Caboodle/DataTransfer/DataTransfer.uwp.cs
+++ b/Caboodle/DataTransfer/DataTransfer.uwp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Caboodle
             {
                 var newRequest = e.Request;
 
-                newRequest.Data.Properties.Title = request.Title ?? DeviceInfo.AppName;
+                newRequest.Data.Properties.Title = request.Title ?? AppInfo.Name;
 
                 if (!string.IsNullOrWhiteSpace(request.Text))
                 {

--- a/Caboodle/DataTransfer/DataTransfer.uwp.cs
+++ b/Caboodle/DataTransfer/DataTransfer.uwp.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class DataTransfer
+    {
+        static ShareTextRequest shareRequest;
+
+        public static Task ShowShareUI(ShareTextRequest request)
+        {
+            shareRequest = request;
+
+            var dataTransferManager = DataTransferManager.GetForCurrentView();
+
+            dataTransferManager.DataRequested += new TypedEventHandler<DataTransferManager, DataRequestedEventArgs>(ShareTextHandler);
+
+            DataTransferManager.ShowShareUI();
+
+            return Task.CompletedTask;
+        }
+
+        static void ShareTextHandler(DataTransferManager sender, DataRequestedEventArgs e)
+        {
+            var request = e.Request;
+
+            request.Data.Properties.Title = shareRequest.Title ?? DeviceInfo.AppName;
+
+            if (!string.IsNullOrWhiteSpace(shareRequest.Text))
+            {
+                request.Data.SetText(shareRequest.Text);
+            }
+
+            if (!string.IsNullOrWhiteSpace(shareRequest.Uri))
+            {
+                request.Data.SetWebLink(new Uri(shareRequest.Uri));
+            }
+
+            shareRequest = null;
+        }
+    }
+}

--- a/Caboodle/DataTransfer/DataTransfer.uwp.cs
+++ b/Caboodle/DataTransfer/DataTransfer.uwp.cs
@@ -13,12 +13,14 @@ namespace Microsoft.Caboodle
         {
             var dataTransferManager = DataTransferManager.GetForCurrentView();
 
-            dataTransferManager.DataRequested += new TypedEventHandler<DataTransferManager, DataRequestedEventArgs>(ShareTextHandler);
+            dataTransferManager.DataRequested += ShareTextHandler;
 
             DataTransferManager.ShowShareUI();
 
             void ShareTextHandler(DataTransferManager sender, DataRequestedEventArgs e)
             {
+                dataTransferManager.DataRequested -= ShareTextHandler;
+
                 var newRequest = e.Request;
 
                 newRequest.Data.Properties.Title = request.Title ?? AppInfo.Name;

--- a/Caboodle/Platform/Platform.ios.cs
+++ b/Caboodle/Platform/Platform.ios.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Foundation;
+using UIKit;
 
 namespace Microsoft.Caboodle
 {
@@ -14,6 +16,37 @@ namespace Microsoft.Caboodle
             }
 
             NSRunLoop.Main.BeginInvokeOnMainThread(action.Invoke);
+        }
+
+        internal static UIViewController GetCurrentViewController(bool throwIfNull = true)
+        {
+            UIViewController viewController = null;
+
+            var window = UIApplication.SharedApplication.KeyWindow;
+
+            if (window.WindowLevel == UIWindowLevel.Normal)
+                viewController = window.RootViewController;
+
+            if (viewController == null)
+            {
+                window = UIApplication.SharedApplication
+                    .Windows
+                    .OrderByDescending(w => w.WindowLevel)
+                    .FirstOrDefault(w => w.RootViewController != null && w.WindowLevel == UIWindowLevel.Normal);
+
+                if (window == null)
+                    throw new InvalidOperationException("Could not find current view controller.");
+                else
+                    viewController = window.RootViewController;
+            }
+
+            while (viewController.PresentedViewController != null)
+                viewController = viewController.PresentedViewController;
+
+            if (throwIfNull && viewController == null)
+                throw new InvalidOperationException("Could not find current view controller.");
+
+            return viewController;
         }
     }
 }

--- a/Samples/Caboodle.Samples.Android/Caboodle.Samples.Android.csproj
+++ b/Samples/Caboodle.Samples.Android/Caboodle.Samples.Android.csproj
@@ -28,6 +28,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidSupportedAbis />
+    <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Caboodle.Samples/Caboodle.Samples.csproj
+++ b/Samples/Caboodle.Samples/Caboodle.Samples.csproj
@@ -20,13 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Caboodle\Caboodle.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="View\DataTransferPage.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-
+  
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 
 </Project>

--- a/Samples/Caboodle.Samples/Caboodle.Samples.csproj
+++ b/Samples/Caboodle.Samples/Caboodle.Samples.csproj
@@ -21,6 +21,12 @@
     <ProjectReference Include="..\..\Caboodle\Caboodle.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="View\DataTransferPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 
 </Project>

--- a/Samples/Caboodle.Samples/View/DataTransferPage.xaml
+++ b/Samples/Caboodle.Samples/View/DataTransferPage.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Caboodle.Samples.View.DataTransferPage"
+             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+             Title="Data Transfer">
+    <ContentPage.BindingContext>
+        <viewmodels:DataTransferViewModel />
+    </ContentPage.BindingContext>
+    <ContentPage.Content>
+        <ScrollView>
+        <StackLayout Padding="8">
+            <Label Text="Share text and websites to other applications on the users device." />
+
+                <Label Text="Title (Optional)"/>
+                <Entry Text="{Binding Title}"/>
+
+
+                <Label Text="Subject (Optional)"/>
+                <Entry Text="{Binding Subject}"/>
+
+                <StackLayout Orientation="Horizontal" Margin="0,8,0,0">
+                    <Label Text="Text" HorizontalOptions="StartAndExpand"/>
+                    <Switch HorizontalOptions="End" IsToggled="{Binding ShareText}"/>
+                </StackLayout>
+                <Entry Text="{Binding Text}" Placeholder="Enter text to share here."/>
+            
+                <StackLayout Orientation="Horizontal" Margin="0,8,0,0">
+                    <Label Text="Uri" HorizontalOptions="StartAndExpand"/>
+                    <Switch HorizontalOptions="End" IsToggled="{Binding ShareUri}"/>
+                </StackLayout>
+                <Entry Text="{Binding Uri}" Placeholder="Enter uri to share here."/>
+
+                <Button Text="Request Transfer" Command="{Binding RequestCommand}"/>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Samples/Caboodle.Samples/View/DataTransferPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/DataTransferPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace Caboodle.Samples.View
+{
+    public partial class DataTransferPage : ContentPage
+    {
+        public DataTransferPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/Caboodle.Samples/ViewModel/DataTransferViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/DataTransferViewModel.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+using Microsoft.Caboodle;
+using Xamarin.Forms;
+
+namespace Caboodle.Samples.ViewModel
+{
+    class DataTransferViewModel : BaseViewModel
+    {
+        public ICommand RequestCommand { get; }
+
+        public DataTransferViewModel()
+        {
+            RequestCommand = new Command(async () =>
+            {
+                await DataTransfer.ShowShareUI(new ShareTextRequest
+                {
+                    Subject = Subject,
+                    Text = ShareText ? Text : null,
+                    Uri = ShareUri ? Uri : null,
+                    Title = Title
+                });
+            });
+        }
+
+        bool shareText = true;
+
+        public bool ShareText
+        {
+            get => shareText;
+            set => SetProperty(ref shareText, value);
+        }
+
+        bool shareUri;
+
+        public bool ShareUri
+        {
+            get => shareUri;
+            set => SetProperty(ref shareUri, value);
+        }
+
+        string text;
+
+        public string Text
+        {
+            get => text;
+            set => SetProperty(ref text, value);
+        }
+
+        string uri;
+
+        public string Uri
+        {
+            get => uri;
+            set => SetProperty(ref uri, value);
+        }
+
+        string subject;
+
+        public string Subject
+        {
+            get => subject;
+            set => SetProperty(ref subject, value);
+        }
+
+        string title;
+
+        public string Title
+        {
+            get => title;
+            set => SetProperty(ref title, value);
+        }
+    }
+}

--- a/Samples/Caboodle.Samples/ViewModel/DataTransferViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/DataTransferViewModel.cs
@@ -15,7 +15,7 @@ namespace Caboodle.Samples.ViewModel
         {
             RequestCommand = new Command(async () =>
             {
-                await DataTransfer.ShowShareUI(new ShareTextRequest
+                await DataTransfer.RequestAsync(new ShareTextRequest
                 {
                     Subject = Subject,
                     Text = ShareText ? Text : null,

--- a/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
@@ -11,6 +11,7 @@ namespace Caboodle.Samples.ViewModel
             Items = new ObservableCollection<SampleItem>
             {
                 new SampleItem("Battery", typeof(BatteryPage), "Easily detect battery level, source, and state."),
+                new SampleItem("Data Transfer", typeof(DataTransferPage), "Send text and website uris to other apps."),
                 new SampleItem("Geocoding", typeof(GeocodingPage), "Easily geocode and reverse geocoding."),
                 new SampleItem("Preferences", typeof(PreferencesPage), "Quickly and easily add persistent preferences."),
                 new SampleItem("Device Info", typeof(DeviceInfoPage), "Find out about the device with ease."),

--- a/docs/en/Microsoft.Caboodle/DataTransfer.xml
+++ b/docs/en/Microsoft.Caboodle/DataTransfer.xml
@@ -16,9 +16,9 @@
     </remarks>
   </Docs>
   <Members>
-    <Member MemberName="ShowShareUI">
-      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (Microsoft.Caboodle.ShareTextRequest request);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(class Microsoft.Caboodle.ShareTextRequest request) cil managed" />
+    <Member MemberName="RequestAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task RequestAsync (Microsoft.Caboodle.ShareTextRequest request);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task RequestAsync(class Microsoft.Caboodle.ShareTextRequest request) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -38,9 +38,9 @@
         </remarks>
       </Docs>
     </Member>
-    <Member MemberName="ShowShareUI">
-      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (string text);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(string text) cil managed" />
+    <Member MemberName="RequestAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task RequestAsync (string text);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task RequestAsync(string text) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -60,9 +60,9 @@
         </remarks>
       </Docs>
     </Member>
-    <Member MemberName="ShowShareUI">
-      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (string text, string title);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(string text, string title) cil managed" />
+    <Member MemberName="RequestAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task RequestAsync (string text, string title);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task RequestAsync(string text, string title) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/docs/en/Microsoft.Caboodle/DataTransfer.xml
+++ b/docs/en/Microsoft.Caboodle/DataTransfer.xml
@@ -1,0 +1,88 @@
+<Type Name="DataTransfer" FullName="Microsoft.Caboodle.DataTransfer">
+  <TypeSignature Language="C#" Value="public static class DataTransfer" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit DataTransfer extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Share data such as text and uris to other applications.</summary>
+    <remarks>
+      <para />
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="ShowShareUI">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (Microsoft.Caboodle.ShareTextRequest request);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(class Microsoft.Caboodle.ShareTextRequest request) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="request" Type="Microsoft.Caboodle.ShareTextRequest" />
+      </Parameters>
+      <Docs>
+        <param name="request">Share request with options.</param>
+        <summary>Show the share user interface to share text or uri.</summary>
+        <returns>Task when completed.</returns>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ShowShareUI">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (string text);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(string text) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="text" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="text">Text to share.</param>
+        <summary>Show the share user interface to share text.</summary>
+        <returns>Task when completed.</returns>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ShowShareUI">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task ShowShareUI (string text, string title);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task ShowShareUI(string text, string title) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="text" Type="System.String" />
+        <Parameter Name="title" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="text">Text to share.</param>
+        <param name="title">Title for the share user interface.</param>
+        <summary>Show the share user interface to share text with a title.</summary>
+        <returns>Task when completed.</returns>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Microsoft.Caboodle/ShareTextRequest.xml
+++ b/docs/en/Microsoft.Caboodle/ShareTextRequest.xml
@@ -1,0 +1,143 @@
+<Type Name="ShareTextRequest" FullName="Microsoft.Caboodle.ShareTextRequest">
+  <TypeSignature Language="C#" Value="public class ShareTextRequest" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareTextRequest extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Standard request for sharing text to other applications.</summary>
+    <remarks>
+      <para />
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ShareTextRequest ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>Default constructor.</summary>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ShareTextRequest (string text);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string text) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="text" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="text">Text to share.</param>
+        <summary>Share request with text.</summary>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ShareTextRequest (string text, string title);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string text, string title) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="text" Type="System.String" />
+        <Parameter Name="title" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="text">Text to share.</param>
+        <param name="title">Title for share user interface.</param>
+        <summary>Share request with text and title.</summary>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Subject">
+      <MemberSignature Language="C#" Value="public string Subject { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Subject" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the subject that is sometimes used for applications such as mail clients.</summary>
+        <value>The subject.</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Text">
+      <MemberSignature Language="C#" Value="public string Text { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Text" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or tsets the main text or message to share.</summary>
+        <value>The main text.</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Title">
+      <MemberSignature Language="C#" Value="public string Title { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Title" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the title to use on the share user interface.</summary>
+        <value>The title to display.</value>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Uri">
+      <MemberSignature Language="C#" Value="public string Uri { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Uri" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets a valid Uri to share.</summary>
+        <value>The uri that will be shared.</value>
+        <remarks>This must be a valid uri or an exception will be thrown.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
### Description of Change ###

Initial support for Share API aka Data Transfer. Leave API open to transferring of other types of data in the future.

### Bugs Fixed ###

- Related to issue #22

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- Task ShowShareUI(ShareTextRequest request)
- Task ShowShareUI(string text)
- Task ShowShareUI(string text, string title)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
