### PR TITLE
GH-95: Moved app info into AppInfo

### DIFF
--- a/Caboodle/AppInfo/AppInfo.android.cs
+++ b/Caboodle/AppInfo/AppInfo.android.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Content.Res;
+using Android.OS;
+using Android.Provider;
+using Android.Runtime;
+using Android.Views;
+using CaboodlePlatform = Microsoft.Caboodle.Platform;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class AppInfo
+    {
+        static string GetPackageName() => CaboodlePlatform.CurrentContext.PackageName;
+
+        static string GetName()
+        {
+            var applicationInfo = CaboodlePlatform.CurrentContext.ApplicationInfo;
+            var packageManager = CaboodlePlatform.CurrentContext.PackageManager;
+            return applicationInfo.LoadLabel(packageManager);
+        }
+
+        static string GetVersionString()
+        {
+            var pm = CaboodlePlatform.CurrentContext.PackageManager;
+            var packageName = CaboodlePlatform.CurrentContext.PackageName;
+            using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+            {
+                return info.VersionName;
+            }
+        }
+
+        static string GetBuild()
+        {
+            var pm = CaboodlePlatform.CurrentContext.PackageManager;
+            var packageName = CaboodlePlatform.CurrentContext.PackageName;
+            using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+            {
+                return info.VersionCode.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+    }
+}

--- a/Caboodle/AppInfo/AppInfo.ios.cs
+++ b/Caboodle/AppInfo/AppInfo.ios.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class AppInfo
+    {
+        static string GetPackageName() => GetBundleValue("CFBundleIdentifier");
+
+        static string GetName() => GetBundleValue("CFBundleDisplayName") ?? GetBundleValue("CFBundleName");
+
+        static string GetVersionString() => GetBundleValue("CFBundleShortVersionString");
+
+        static string GetBuild() => GetBundleValue("CFBundleVersion");
+
+        static string GetBundleValue(string key)
+           => NSBundle.MainBundle.ObjectForInfoDictionary(key).ToString();
+    }
+}

--- a/Caboodle/AppInfo/AppInfo.netstandard.cs
+++ b/Caboodle/AppInfo/AppInfo.netstandard.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class AppInfo
+    {
+        static string GetPackageName() => throw new NotImplementedInReferenceAssemblyException();
+
+        static string GetName() => throw new NotImplementedInReferenceAssemblyException();
+
+        static string GetVersionString() => throw new NotImplementedInReferenceAssemblyException();
+
+        static string GetBuild() => throw new NotImplementedInReferenceAssemblyException();
+    }
+}

--- a/Caboodle/AppInfo/AppInfo.shared.cs
+++ b/Caboodle/AppInfo/AppInfo.shared.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class AppInfo
+    {
+        public static string PackageName => GetPackageName();
+
+        public static string Name => GetName();
+
+        public static string VersionString => GetVersionString();
+
+        public static Version Version => Utils.ParseVersion(VersionString);
+
+        public static string BuildString => GetBuild();
+    }
+}

--- a/Caboodle/AppInfo/AppInfo.uwp.cs
+++ b/Caboodle/AppInfo/AppInfo.uwp.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
+using Windows.Graphics.Display;
+using Windows.Security.ExchangeActiveSyncProvisioning;
+using Windows.System.Profile;
+using Windows.UI.ViewManagement;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class AppInfo
+    {
+        static string GetPackageName() => Package.Current.Id.Name;
+
+        static string GetName() => Package.Current.DisplayName;
+
+        static string GetVersionString()
+        {
+            var version = Package.Current.Id.Version;
+            return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+        }
+
+        static string GetBuild()
+            => Package.Current.Id.Version.Build.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/Caboodle/DeviceInfo/DeviceInfo.android.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.android.cs
@@ -33,35 +33,6 @@ namespace Microsoft.Caboodle
 
         static string GetVersionString() => Build.VERSION.Release;
 
-        static string GetAppPackageName() => CaboodlePlatform.CurrentContext.PackageName;
-
-        static string GetAppName()
-        {
-            var applicationInfo = CaboodlePlatform.CurrentContext.ApplicationInfo;
-            var packageManager = CaboodlePlatform.CurrentContext.PackageManager;
-            return applicationInfo.LoadLabel(packageManager);
-        }
-
-        static string GetAppVersionString()
-        {
-            var pm = CaboodlePlatform.CurrentContext.PackageManager;
-            var packageName = CaboodlePlatform.CurrentContext.PackageName;
-            using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
-            {
-                return info.VersionName;
-            }
-        }
-
-        static string GetAppBuild()
-        {
-            var pm = CaboodlePlatform.CurrentContext.PackageManager;
-            var packageName = CaboodlePlatform.CurrentContext.PackageName;
-            using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
-            {
-                return info.VersionCode.ToString(CultureInfo.InvariantCulture);
-            }
-        }
-
         static string GetPlatform() => Platforms.Android;
 
         static string GetIdiom()

--- a/Caboodle/DeviceInfo/DeviceInfo.ios.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.ios.cs
@@ -18,14 +18,6 @@ namespace Microsoft.Caboodle
 
         static string GetVersionString() => UIDevice.CurrentDevice.SystemVersion;
 
-        static string GetAppPackageName() => GetBundleValue("CFBundleIdentifier");
-
-        static string GetAppName() => GetBundleValue("CFBundleDisplayName") ?? GetBundleValue("CFBundleName");
-
-        static string GetAppVersionString() => GetBundleValue("CFBundleShortVersionString");
-
-        static string GetAppBuild() => GetBundleValue("CFBundleVersion");
-
         static string GetPlatform() => Platforms.iOS;
 
         static string GetIdiom()
@@ -110,8 +102,5 @@ namespace Microsoft.Caboodle
 
             return ScreenRotation.Rotation0;
         }
-
-        static string GetBundleValue(string key)
-           => NSBundle.MainBundle.ObjectForInfoDictionary(key).ToString();
     }
 }

--- a/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.netstandard.cs
@@ -12,14 +12,6 @@ namespace Microsoft.Caboodle
 
         static string GetVersionString() => throw new NotImplementedInReferenceAssemblyException();
 
-        static string GetAppPackageName() => throw new NotImplementedInReferenceAssemblyException();
-
-        static string GetAppName() => throw new NotImplementedInReferenceAssemblyException();
-
-        static string GetAppVersionString() => throw new NotImplementedInReferenceAssemblyException();
-
-        static string GetAppBuild() => throw new NotImplementedInReferenceAssemblyException();
-
         static string GetPlatform() => throw new NotImplementedInReferenceAssemblyException();
 
         static string GetIdiom() => throw new NotImplementedInReferenceAssemblyException();

--- a/Caboodle/DeviceInfo/DeviceInfo.shared.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.shared.cs
@@ -15,17 +15,7 @@ namespace Microsoft.Caboodle
 
         public static string VersionString => GetVersionString();
 
-        public static Version Version => ParseVersion(VersionString);
-
-        public static string AppPackageName => GetAppPackageName();
-
-        public static string AppName => GetAppName();
-
-        public static string AppVersionString => GetAppVersionString();
-
-        public static Version AppVersion => ParseVersion(AppVersionString);
-
-        public static string AppBuildString => GetAppBuild();
+        public static Version Version => Utils.ParseVersion(VersionString);
 
         public static string Platform => GetPlatform();
 
@@ -63,14 +53,6 @@ namespace Microsoft.Caboodle
 
         static void OnScreenMetricsChanaged(ScreenMetricsChanagedEventArgs e)
             => ScreenMetricsChanagedInternal?.Invoke(e);
-
-        static Version ParseVersion(string version)
-        {
-            if (Version.TryParse(version, out var number))
-                return number;
-
-            return new Version(0, 0);
-        }
 
         public static class Idioms
         {

--- a/Caboodle/DeviceInfo/DeviceInfo.uwp.cs
+++ b/Caboodle/DeviceInfo/DeviceInfo.uwp.cs
@@ -39,19 +39,6 @@ namespace Microsoft.Caboodle
             return version;
         }
 
-        static string GetAppPackageName() => Package.Current.Id.Name;
-
-        static string GetAppName() => Package.Current.DisplayName;
-
-        static string GetAppVersionString()
-        {
-            var version = Package.Current.Id.Version;
-            return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
-        }
-
-        static string GetAppBuild()
-            => Package.Current.Id.Version.Build.ToString(CultureInfo.InvariantCulture);
-
         static string GetPlatform() => Platforms.UWP;
 
         static string GetIdiom()

--- a/Caboodle/Shared/Utils.shared.cs
+++ b/Caboodle/Shared/Utils.shared.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Caboodle
+{
+    class Utils
+    {
+        public static Version ParseVersion(string version)
+        {
+            if (Version.TryParse(version, out var number))
+                return number;
+
+            return new Version(0, 0);
+        }
+    }
+}

--- a/DeviceTests/Caboodle.DeviceTests.Shared/DeviceInfo_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/DeviceInfo_Tests.cs
@@ -22,18 +22,18 @@ namespace Caboodle.DeviceTests
         [Fact]
         public void AppName_Is_Correct()
         {
-            Assert.Equal("Caboodle Tests", DeviceInfo.AppName);
+            Assert.Equal("Caboodle Tests", AppInfo.Name);
         }
 
         [Fact]
         public void AppPackageName_Is_Correct()
         {
 #if WINDOWS_UWP
-            Assert.Equal("ec0cc741-fd3e-485c-81be-68815c480690", DeviceInfo.AppPackageName);
+            Assert.Equal("ec0cc741-fd3e-485c-81be-68815c480690", AppInfo.PackageName);
 #elif __IOS__
-            Assert.Equal("com.xamarin.caboodle.devicetests", DeviceInfo.AppPackageName);
+            Assert.Equal("com.xamarin.caboodle.devicetests", AppInfo.PackageName);
 #elif __ANDROID__
-            Assert.Equal("com.xamarin.caboodle.devicetests", DeviceInfo.AppPackageName);
+            Assert.Equal("com.xamarin.caboodle.devicetests", AppInfo.PackageName);
 #else
             throw new PlatformNotSupportedException();
 #endif
@@ -56,14 +56,14 @@ namespace Caboodle.DeviceTests
         [Fact]
         public void App_Build_Is_Correct()
         {
-            Assert.Equal("1", DeviceInfo.AppBuildString);
+            Assert.Equal("1", AppInfo.BuildString);
         }
 
         [Fact]
         public void App_Versions_Are_Correct()
         {
-            Assert.Equal("1.0.1.0", DeviceInfo.AppVersionString);
-            Assert.Equal(new Version(1, 0, 1, 0), DeviceInfo.AppVersion);
+            Assert.Equal("1.0.1.0", AppInfo.VersionString);
+            Assert.Equal(new Version(1, 0, 1, 0), AppInfo.Version);
         }
 
         [Fact]

--- a/Samples/Caboodle.Samples/ViewModel/DeviceInfoViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/DeviceInfoViewModel.cs
@@ -18,13 +18,13 @@ namespace Caboodle.Samples.ViewModel
 
         public string Version => DeviceInfo.VersionString;
 
-        public string AppPackageName => DeviceInfo.AppPackageName;
+        public string AppPackageName => AppInfo.PackageName;
 
-        public string AppName => DeviceInfo.AppName;
+        public string AppName => AppInfo.Name;
 
-        public string AppVersion => DeviceInfo.AppVersionString;
+        public string AppVersion => AppInfo.VersionString;
 
-        public string AppBuild => DeviceInfo.AppBuildString;
+        public string AppBuild => AppInfo.BuildString;
 
         public string Platform => DeviceInfo.Platform;
 

--- a/docs/en/Microsoft.Caboodle/AppInfo.xml
+++ b/docs/en/Microsoft.Caboodle/AppInfo.xml
@@ -1,0 +1,98 @@
+<Type Name="AppInfo" FullName="Microsoft.Caboodle.AppInfo">
+  <TypeSignature Language="C#" Value="public static class AppInfo" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit AppInfo extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Represents information about the application.</summary>
+    <remarks></remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="BuildString">
+      <MemberSignature Language="C#" Value="public static string BuildString { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property string BuildString" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the application build number.</summary>
+        <value>The application build number.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Name">
+      <MemberSignature Language="C#" Value="public static string Name { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property string Name" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the application name.</summary>
+        <value>The application name.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PackageName">
+      <MemberSignature Language="C#" Value="public static string PackageName { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property string PackageName" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the application package name or identifier.</summary>
+        <value>The package name or identifier.</value>
+        <remarks>On android and iOS, this is the application package name. On UWP, this is the application GUID.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Version">
+      <MemberSignature Language="C#" Value="public static Version Version { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property class System.Version Version" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Version</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the application version.</summary>
+        <value>The application version.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="VersionString">
+      <MemberSignature Language="C#" Value="public static string VersionString { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property string VersionString" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the application version.</summary>
+        <value>The application version.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -220,6 +220,7 @@
   <Copyright>To be added.</Copyright>
   <Types>
     <Namespace Name="Microsoft.Caboodle">
+      <Type Name="AppInfo" Kind="Class" />
       <Type Name="FileSystem" Kind="Class" />
       <Type Name="NotImplentedInReferenceAssembly" Kind="Class" />
       <Type Name="Platform" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

Moved the app information properties into a new type called: `AppInfo`

### Bugs Fixed ###

- Related to issue #95

### API Changes ###

List all API changes here (or just put None), example:

Added: 

```csharp
static class AppInfo {
    static string PackageName { get; }
    static string Name { get; }
    static string VersionString { get; }
    static Version Version { get; }
    static string BuildString { get; }
```

Removed:

```csharp
static class DeviceInfo {
    static string AppPackageName { get; }
    static string AppName { get; }
    static string AppVersionString { get; }
    static Version AppVersion { get; }
    static string AppBuildString { get; }
```

### Behavioral Changes ###

Moved the app-related properties from the `DeviceInfo` type into the `AppInfo` type.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
