### PR TITLE
GH-94: Only generate docs for current assembly

### DIFF
--- a/Caboodle/mdoc.targets
+++ b/Caboodle/mdoc.targets
@@ -80,7 +80,7 @@
       <MDocReferenceAssembly Include="$(FrameowrkReferenceAssemblyPath)\Xamarin.Mac\v2.0" />
     </ItemGroup>
     <ItemGroup>
-      <MDocAssembly Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\**\*.dll" />
+      <MDocAssembly Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\**\$(AssemblyName).dll" />
     </ItemGroup>
     <PropertyGroup>
       <MDocReferenceAssemblies>@(MDocReferenceAssembly -> '--lib=&quot;%(Identity)&quot;', ' ')</MDocReferenceAssemblies>

--- a/docs/en/Microsoft.Caboodle/Platform.xml
+++ b/docs/en/Microsoft.Caboodle/Platform.xml
@@ -14,19 +14,6 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName=".ctor">
-      <MemberSignature Language="C#" Value="public Platform ();" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
-      <MemberType>Constructor</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <Parameters />
-      <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="Init">
       <MemberSignature Language="C#" Value="public static void Init (Android.App.Activity activity, Android.OS.Bundle bundle);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Init(class Android.App.Activity activity, class Android.OS.Bundle bundle) cil managed" />


### PR DESCRIPTION
### Description of Change ###

Only generate docs for Microsoft.Caboodle.dll.

### Bugs Fixed ###

- Related to issue #94

### API Changes ###

None.

### Behavioral Changes ###

Only changes to what assemblies are used to generate docs.
