### PR TITLE
GH-25: Add PhoneDialer API

### DIFF
--- a/Caboodle.Tests/PhoneDialer_Tests.cs
+++ b/Caboodle.Tests/PhoneDialer_Tests.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Caboodle;
+using Xunit;
+
+namespace Caboodle.Tests
+{
+    public class PhoneDialer_Tests
+    {
+        [Fact]
+        public void Dialer_Supported_Fail_On_NetStandard() =>
+            Assert.Throws<NotImplentedInReferenceAssembly>(() => PhoneDialer.IsSupported);
+
+        [Fact]
+        public void Dialer_Open_Fail_On_NetStandard() =>
+            Assert.Throws<NotImplentedInReferenceAssembly>(() => PhoneDialer.Open("1234567890"));
+    }
+}

--- a/Caboodle.Tests/PhoneDialer_Tests.cs
+++ b/Caboodle.Tests/PhoneDialer_Tests.cs
@@ -6,11 +6,7 @@ namespace Caboodle.Tests
     public class PhoneDialer_Tests
     {
         [Fact]
-        public void Dialer_Supported_Fail_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => PhoneDialer.IsSupported);
-
-        [Fact]
         public void Dialer_Open_Fail_On_NetStandard() =>
-            Assert.Throws<NotImplentedInReferenceAssembly>(() => PhoneDialer.Open("1234567890"));
+            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => PhoneDialer.Open("1234567890"));
     }
 }

--- a/Caboodle/Caboodle.csproj
+++ b/Caboodle/Caboodle.csproj
@@ -50,6 +50,9 @@
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
     <Compile Include="**\*.uwp.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">

--- a/Caboodle/PhoneDialer/PhoneDialer.android.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.android.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Caboodle
 
             if (!IsSupported)
             {
-                throw new CapabilityNotSupportedException();
+                throw new FeatureNotSupportedException();
             }
 
             string phoneNumber;

--- a/Caboodle/PhoneDialer/PhoneDialer.android.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.android.cs
@@ -10,29 +10,23 @@ namespace Microsoft.Caboodle
 {
     public static partial class PhoneDialer
     {
-        public static bool IsSupported
+        const string intentCheck = "00000000000";
+
+        static bool IsSupported
         {
             get
             {
                 var packageManager = Application.Context.PackageManager;
-                var dialIntent = ResolveDialIntent(new string('0', 10));
+                var dialIntent = ResolveDialIntent(intentCheck);
                 return dialIntent.ResolveActivity(packageManager) != null;
             }
         }
 
         public static void Open(string number)
         {
-            if (string.IsNullOrWhiteSpace(number))
-            {
-                throw new ArgumentNullException(nameof(number));
-            }
+            ValidateOpen(number);
 
-            if (!IsSupported)
-            {
-                throw new FeatureNotSupportedException();
-            }
-
-            string phoneNumber;
+            var phoneNumber = string.Empty;
             if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
             {
                 phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.GetDefault(Locale.Category.Format).Country);

--- a/Caboodle/PhoneDialer/PhoneDialer.android.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.android.cs
@@ -27,11 +27,11 @@ namespace Microsoft.Caboodle
             ValidateOpen(number);
 
             var phoneNumber = string.Empty;
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
+            if (Platform.HasNougat)
             {
                 phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.GetDefault(Locale.Category.Format).Country);
             }
-            else if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+            else if (Platform.HasLollipop)
             {
                 phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.Default.Country);
             }

--- a/Caboodle/PhoneDialer/PhoneDialer.android.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.android.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Caboodle
     {
         const string intentCheck = "00000000000";
 
-        static bool IsSupported
+        internal static bool IsSupported
         {
             get
             {

--- a/Caboodle/PhoneDialer/PhoneDialer.android.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.android.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Telephony;
+using Java.Util;
+using Uri = Android.Net.Uri;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class PhoneDialer
+    {
+        public static bool IsSupported
+        {
+            get
+            {
+                var packageManager = Application.Context.PackageManager;
+                var dialIntent = ResolveDialIntent(new string('0', 10));
+                return dialIntent.ResolveActivity(packageManager) != null;
+            }
+        }
+
+        public static void Open(string number)
+        {
+            if (string.IsNullOrWhiteSpace(number))
+            {
+                throw new ArgumentNullException(nameof(number));
+            }
+
+            if (!IsSupported)
+            {
+                throw new CapabilityNotSupportedException();
+            }
+
+            string phoneNumber;
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
+            {
+                phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.GetDefault(Locale.Category.Format).Country);
+            }
+            else if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+            {
+                phoneNumber = PhoneNumberUtils.FormatNumber(number, Locale.Default.Country);
+            }
+            else
+            {
+#pragma warning disable CS0618
+                phoneNumber = PhoneNumberUtils.FormatNumber(number);
+#pragma warning restore CS0618
+            }
+
+            var dialIntent = ResolveDialIntent(phoneNumber)
+                .SetFlags(ActivityFlags.ClearTop)
+                .SetFlags(ActivityFlags.NewTask);
+
+            Application.Context.StartActivity(dialIntent);
+        }
+
+        static Intent ResolveDialIntent(string number)
+        {
+            var telUri = Uri.Parse($"tel:{number}");
+            return new Intent(Intent.ActionDial, telUri);
+        }
+    }
+}

--- a/Caboodle/PhoneDialer/PhoneDialer.ios.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.ios.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using CoreTelephony;
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class PhoneDialer
+    {
+        const string noNetworkProviderCode = "65535";
+
+        public static bool IsSupported
+        {
+            get
+            {
+                var isDialerInstalled = UIApplication.SharedApplication.CanOpenUrl(CreateNsUrl(new string('0', 10)));
+                if (!isDialerInstalled)
+                {
+                    return false;
+                }
+
+                using (var netInfo = new CTTelephonyNetworkInfo())
+                {
+                    var mnc = netInfo.SubscriberCellularProvider?.MobileNetworkCode;
+                    return !string.IsNullOrEmpty(mnc) && mnc != noNetworkProviderCode;
+                }
+            }
+        }
+
+        public static void Open(string number)
+        {
+            if (string.IsNullOrWhiteSpace(number))
+            {
+                throw new ArgumentNullException(nameof(number));
+            }
+
+            if (!IsSupported)
+            {
+                throw new CapabilityNotSupportedException();
+            }
+
+            var nsUrl = CreateNsUrl(number);
+            UIApplication.SharedApplication.OpenUrl(nsUrl);
+        }
+
+        static NSUrl CreateNsUrl(string number) => new NSUrl(new Uri($"tel:{number}").AbsoluteUri);
+    }
+}

--- a/Caboodle/PhoneDialer/PhoneDialer.ios.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.ios.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Caboodle
 
             if (!IsSupported)
             {
-                throw new CapabilityNotSupportedException();
+                throw new FeatureNotSupportedException();
             }
 
             var nsUrl = CreateNsUrl(number);

--- a/Caboodle/PhoneDialer/PhoneDialer.ios.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.ios.cs
@@ -29,15 +29,7 @@ namespace Microsoft.Caboodle
 
         public static void Open(string number)
         {
-            if (string.IsNullOrWhiteSpace(number))
-            {
-                throw new ArgumentNullException(nameof(number));
-            }
-
-            if (!IsSupported)
-            {
-                throw new FeatureNotSupportedException();
-            }
+            ValidateOpen(number);
 
             var nsUrl = CreateNsUrl(number);
             UIApplication.SharedApplication.OpenUrl(nsUrl);

--- a/Caboodle/PhoneDialer/PhoneDialer.ios.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.ios.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Caboodle
     {
         const string noNetworkProviderCode = "65535";
 
-        public static bool IsSupported
+        internal static bool IsSupported
         {
             get
             {

--- a/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
@@ -3,9 +3,9 @@
     public static partial class PhoneDialer
     {
         public static bool IsSupported =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
 
         public static void Open(string number) =>
-            throw new NotImplentedInReferenceAssembly();
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
@@ -2,7 +2,7 @@
 {
     public static partial class PhoneDialer
     {
-        public static bool IsSupported =>
+        internal static bool IsSupported =>
             throw new NotImplementedInReferenceAssemblyException();
 
         public static void Open(string number) =>

--- a/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.netstandard.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Caboodle
+{
+    public static partial class PhoneDialer
+    {
+        public static bool IsSupported =>
+            throw new NotImplentedInReferenceAssembly();
+
+        public static void Open(string number) =>
+            throw new NotImplentedInReferenceAssembly();
+    }
+}

--- a/Caboodle/PhoneDialer/PhoneDialer.shared.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.shared.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class PhoneDialer
+    {
+        internal static void ValidateOpen(string number)
+        {
+            if (string.IsNullOrWhiteSpace(number))
+            {
+                throw new ArgumentNullException(nameof(number));
+            }
+
+            if (!IsSupported)
+            {
+                throw new FeatureNotSupportedException();
+            }
+        }
+    }
+}

--- a/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Caboodle
 
             if (!IsSupported)
             {
-                throw new CapabilityNotSupportedException();
+                throw new FeatureNotSupportedException();
             }
 
             PhoneCallManager.ShowPhoneCallUI(number, name ?? string.Empty);

--- a/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Windows.ApplicationModel.Calls;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class PhoneDialer
+    {
+        public static bool IsSupported =>
+             Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager");
+
+        public static void Open(string number) => Open(number, null);
+
+        public static void Open(string number, string name)
+        {
+            if (string.IsNullOrWhiteSpace(number))
+            {
+                throw new ArgumentNullException(nameof(number));
+            }
+
+            if (!IsSupported)
+            {
+                throw new CapabilityNotSupportedException();
+            }
+
+            PhoneCallManager.ShowPhoneCallUI(number, name ?? string.Empty);
+        }
+    }
+}

--- a/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
@@ -12,15 +12,7 @@ namespace Microsoft.Caboodle
 
         public static void Open(string number, string name)
         {
-            if (string.IsNullOrWhiteSpace(number))
-            {
-                throw new ArgumentNullException(nameof(number));
-            }
-
-            if (!IsSupported)
-            {
-                throw new FeatureNotSupportedException();
-            }
+            ValidateOpen(number);
 
             PhoneCallManager.ShowPhoneCallUI(number, name ?? string.Empty);
         }

--- a/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Windows.ApplicationModel.Calls;
+using Windows.Foundation.Metadata;
 
 namespace Microsoft.Caboodle
 {
     public static partial class PhoneDialer
     {
         internal static bool IsSupported =>
-             Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager");
+             ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager");
 
         public static void Open(string number)
         {

--- a/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
+++ b/Caboodle/PhoneDialer/PhoneDialer.uwp.cs
@@ -5,16 +5,14 @@ namespace Microsoft.Caboodle
 {
     public static partial class PhoneDialer
     {
-        public static bool IsSupported =>
+        internal static bool IsSupported =>
              Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager");
 
-        public static void Open(string number) => Open(number, null);
-
-        public static void Open(string number, string name)
+        public static void Open(string number)
         {
             ValidateOpen(number);
 
-            PhoneCallManager.ShowPhoneCallUI(number, name ?? string.Empty);
+            PhoneCallManager.ShowPhoneCallUI(number, string.Empty);
         }
     }
 }

--- a/Caboodle/Platform/Platform.android.cs
+++ b/Caboodle/Platform/Platform.android.cs
@@ -41,6 +41,33 @@ namespace Microsoft.Caboodle
             return activities.Any();
         }
 
+        internal static bool HasKitKat =>
+            (int)Build.VERSION.SdkInt >= 19;
+
+        internal static bool HasKitKatWatch =>
+            (int)Build.VERSION.SdkInt >= 20;
+
+        internal static bool HasLollipop =>
+            (int)Build.VERSION.SdkInt >= 21;
+
+        internal static bool HasLollipopMr1 =>
+            (int)Build.VERSION.SdkInt >= 22;
+
+        internal static bool HasMarshmallow =>
+           (int)Build.VERSION.SdkInt >= 23;
+
+        internal static bool HasNougat =>
+            (int)Build.VERSION.SdkInt >= 24;
+
+        internal static bool HasNougatMr1 =>
+            (int)Build.VERSION.SdkInt >= 25;
+
+        internal static bool HasOreo =>
+            (int)Build.VERSION.SdkInt >= 26;
+
+        internal static bool HasOreoMr1 =>
+            (int)Build.VERSION.SdkInt >= 27;
+
         public static void BeginInvokeOnMainThread(Action action)
         {
             if (handler?.Looper != Looper.MainLooper)

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Caboodle.DeviceTests.Shared.projitems
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Caboodle.DeviceTests.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Clipboard_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceInfo_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Geocoding_Tests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PhoneDialer_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScreenLock_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Preferences_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileSystem_Tests.cs" />

--- a/DeviceTests/Caboodle.DeviceTests.Shared/PhoneDialer_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/PhoneDialer_Tests.cs
@@ -5,7 +5,5 @@ namespace Caboodle.DeviceTests
 {
     public class PhoneDialer_Tests
     {
-        [Fact]
-        public void Dialer_Is_Supported() => Assert.True(PhoneDialer.IsSupported);
     }
 }

--- a/DeviceTests/Caboodle.DeviceTests.Shared/PhoneDialer_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/PhoneDialer_Tests.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Caboodle;
+using Xunit;
+
+namespace Caboodle.DeviceTests
+{
+    public class PhoneDialer_Tests
+    {
+        [Fact]
+        public void Dialer_Is_Supported() => Assert.True(PhoneDialer.IsSupported);
+    }
+}

--- a/DeviceTests/Caboodle.DeviceTests.UWP/Caboodle.DeviceTests.UWP.csproj
+++ b/DeviceTests/Caboodle.DeviceTests.UWP/Caboodle.DeviceTests.UWP.csproj
@@ -99,6 +99,11 @@
     <PackageReference Include="xunit.runner.devices" Version="2.3.3" />
   </ItemGroup>
   <ItemGroup>
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Caboodle\Caboodle.csproj">
       <Project>{63a4f6a1-48bf-4d32-aed7-82f605edb042}</Project>
       <Name>Caboodle</Name>

--- a/Samples/Caboodle.Samples.UWP/Caboodle.Samples.UWP.csproj
+++ b/Samples/Caboodle.Samples.UWP/Caboodle.Samples.UWP.csproj
@@ -94,6 +94,11 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Caboodle\Caboodle.csproj">
       <Project>{63a4f6a1-48bf-4d32-aed7-82f605edb042}</Project>
       <Name>Caboodle</Name>

--- a/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
+++ b/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Caboodle.Samples.View.PhoneDialerPage"
-             Title="PhoneDialer"
-             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel">
+             xmlns:views="clr-namespace:Caboodle.Samples.View"
+             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+             Title="PhoneDialer">
     <ContentPage.BindingContext>
         <viewmodels:PhoneDialerViewModel />
     </ContentPage.BindingContext>
-
     <StackLayout>
         <Label Text="Easily open phone dialer." FontAttributes="Bold" Margin="12" />
 
@@ -20,4 +20,4 @@
         </ScrollView>
     </StackLayout>
 
-</ContentPage>
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
+++ b/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Caboodle.Samples.View.PhoneDialerPage"
+             Title="PhoneDialer"
+             xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel">
+    <ContentPage.BindingContext>
+        <viewmodels:PhoneDialerViewModel />
+    </ContentPage.BindingContext>
+
+    <StackLayout>
+        <Label Text="Easily open phone dialer." FontAttributes="Bold" Margin="12" />
+
+        <ScrollView>
+            <StackLayout Padding="12,0,12,12" Spacing="6">
+                <Label Text="{Binding IsSupportedMessage}" />
+                <Label Text="Phone number:"/>
+                <Entry Text="{Binding PhoneNumber}" Keyboard="Telephone" />
+                <Button Text="Open Phone Dialer" Command="{Binding OpenPhoneDialerCommand}" IsEnabled="{Binding IsEnabled}" />
+            </StackLayout>
+        </ScrollView>
+    </StackLayout>
+
+</ContentPage>

--- a/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
+++ b/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml
@@ -13,7 +13,6 @@
 
         <ScrollView>
             <StackLayout Padding="12,0,12,12" Spacing="6">
-                <Label Text="{Binding IsSupportedMessage}" />
                 <Label Text="Phone number:"/>
                 <Entry Text="{Binding PhoneNumber}" Keyboard="Telephone" />
                 <Button Text="Open Phone Dialer" Command="{Binding OpenPhoneDialerCommand}" IsEnabled="{Binding IsEnabled}" />

--- a/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Caboodle.Samples.View
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class PhoneDialerPage : ContentPage
+    {
+        public PhoneDialerPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/PhoneDialerPage.xaml.cs
@@ -1,10 +1,6 @@
-﻿using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
-
-namespace Caboodle.Samples.View
+﻿namespace Caboodle.Samples.View
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class PhoneDialerPage : ContentPage
+    public partial class PhoneDialerPage : BasePage
     {
         public PhoneDialerPage()
         {

--- a/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
@@ -11,6 +11,7 @@ namespace Caboodle.Samples.ViewModel
             Items = new ObservableCollection<SampleItem>
             {
                 new SampleItem("Battery", typeof(BatteryPage), "Easily detect battery level, source, and state."),
+                new SampleItem("Browser", typeof(BrowserPage), "Quickly and easily open a browser to a specific website."),
                 new SampleItem("Clipboard", typeof(ClipboardPage), "Quickly and easily use clipboard"),
                 new SampleItem("Data Transfer", typeof(DataTransferPage), "Send text and website uris to other apps."),
                 new SampleItem("Device Info", typeof(DeviceInfoPage), "Find out about the device with ease."),

--- a/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
@@ -11,12 +11,12 @@ namespace Caboodle.Samples.ViewModel
             Items = new ObservableCollection<SampleItem>
             {
                 new SampleItem("Battery", typeof(BatteryPage), "Easily detect battery level, source, and state."),
-                new SampleItem("Browser", typeof(BrowserPage), "Quickly and easily open a browser to a specific website."),
                 new SampleItem("Clipboard", typeof(ClipboardPage), "Quickly and easily use clipboard"),
                 new SampleItem("Data Transfer", typeof(DataTransferPage), "Send text and website uris to other apps."),
                 new SampleItem("Device Info", typeof(DeviceInfoPage), "Find out about the device with ease."),
                 new SampleItem("File System", typeof(FileSystemPage), "Easily save files to app data."),
                 new SampleItem("Geocoding", typeof(GeocodingPage), "Easily geocode and reverse geocoding."),
+                new SampleItem("Phone Dialer", typeof(PhoneDialerPage), "Easily open phone dialer."),
                 new SampleItem("Preferences", typeof(PreferencesPage), "Quickly and easily add persistent preferences."),
                 new SampleItem("Screen Lock", typeof(ScreenLockPage), "Keep the device screen awake."),
                 new SampleItem("SMS", typeof(SMSPage), "Easily send SMS messages."),

--- a/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 using Microsoft.Caboodle;
 using Xamarin.Forms;
 
@@ -15,22 +16,22 @@ namespace Caboodle.Samples.ViewModel
 
         public ICommand OpenPhoneDialerCommand { get; }
 
-        public bool IsEnabled => PhoneDialer.IsSupported && !string.IsNullOrEmpty(PhoneNumber);
-
-        public string IsSupportedMessage => $"Is supported? {PhoneDialer.IsSupported}";
-
         public string PhoneNumber
         {
             get => phoneNumber;
-            set
-            {
-                if (SetProperty(ref phoneNumber, value))
-                {
-                    OnPropertyChanged(nameof(IsEnabled));
-                }
-            }
+            set => SetProperty(ref phoneNumber, value);
         }
 
-        void OnOpenPhoneDialer() => PhoneDialer.Open(PhoneNumber);
+        async void OnOpenPhoneDialer()
+        {
+            try
+            {
+                PhoneDialer.Open(PhoneNumber);
+            }
+            catch (Exception)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "Dialer is not supported.", "OK");
+            }
+        }
     }
 }

--- a/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
@@ -30,7 +30,7 @@ namespace Caboodle.Samples.ViewModel
             }
             catch (Exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "Dialer is not supported.", "OK");
+                await DisplayAlert("Dialer is not supported.");
             }
         }
     }

--- a/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/PhoneDialerViewModel.cs
@@ -1,0 +1,36 @@
+﻿using System.Windows.Input;
+using Microsoft.Caboodle;
+using Xamarin.Forms;
+
+namespace Caboodle.Samples.ViewModel
+{
+    public class PhoneDialerViewModel : BaseViewModel
+    {
+        string phoneNumber;
+
+        public PhoneDialerViewModel()
+        {
+            OpenPhoneDialerCommand = new Command(OnOpenPhoneDialer);
+        }
+
+        public ICommand OpenPhoneDialerCommand { get; }
+
+        public bool IsEnabled => PhoneDialer.IsSupported && !string.IsNullOrEmpty(PhoneNumber);
+
+        public string IsSupportedMessage => $"Is supported? {PhoneDialer.IsSupported}";
+
+        public string PhoneNumber
+        {
+            get => phoneNumber;
+            set
+            {
+                if (SetProperty(ref phoneNumber, value))
+                {
+                    OnPropertyChanged(nameof(IsEnabled));
+                }
+            }
+        }
+
+        void OnOpenPhoneDialer() => PhoneDialer.Open(PhoneNumber);
+    }
+}

--- a/docs/en/Microsoft.Caboodle/PhoneDialer.xml
+++ b/docs/en/Microsoft.Caboodle/PhoneDialer.xml
@@ -33,8 +33,7 @@
         <param name="number">Phone number to initialize the dialer with. Example 15555555555</param>
         <summary>Open the phone dialer to a specific phone number.</summary>
         <remarks>
-          <para />
-        </remarks>
+          <para></para>Throws ArgumentNullException if number is not valid.<para>Throws FeatureNotSupportedException if placing phone call is not supported on the device.</para></remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/en/Microsoft.Caboodle/PhoneDialer.xml
+++ b/docs/en/Microsoft.Caboodle/PhoneDialer.xml
@@ -1,0 +1,41 @@
+<Type Name="PhoneDialer" FullName="Microsoft.Caboodle.PhoneDialer">
+  <TypeSignature Language="C#" Value="public static class PhoneDialer" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit PhoneDialer extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>Microsoft.Caboodle</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Open the platform phone dialer to place a call.</summary>
+    <remarks>
+      <para></para>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Open">
+      <MemberSignature Language="C#" Value="public static void Open (string number);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Open(string number) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="number" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="number">Phone number to initialize the dialer with. Example 15555555555</param>
+        <summary>Open the phone dialer to a specific phone number.</summary>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -3,13 +3,13 @@
     <Assembly Name="Microsoft.Caboodle" Version="1.0.0.0">
       <Attributes>
         <Attribute>
-          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.Default | System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints | System.Diagnostics.DebuggableAttribute+DebuggingModes.EnableEditAndContinue)</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyCompany("Microsoft")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyConfiguration("Release")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyConfiguration("Debug")</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")</AttributeName>
@@ -54,6 +54,8 @@
       <Type Name="BatteryChangedEventHandler" Kind="Delegate" />
       <Type Name="BatteryPowerSource" Kind="Enumeration" />
       <Type Name="BatteryState" Kind="Enumeration" />
+      <Type Name="Browser" Kind="Class" />
+      <Type Name="BrowserLaunchType" Kind="Enumeration" />
       <Type Name="Clipboard" Kind="Class" />
       <Type Name="DataTransfer" Kind="Class" />
       <Type Name="DeviceInfo" Kind="Class" />
@@ -68,6 +70,7 @@
       <Type Name="LocationExtensions" Kind="Class" />
       <Type Name="NotImplementedInReferenceAssemblyException" Kind="Class" />
       <Type Name="PermissionException" Kind="Class" />
+      <Type Name="PhoneDialer" Kind="Class" />
       <Type Name="Placemark" Kind="Class" />
       <Type Name="Platform" Kind="Class" />
       <Type Name="Preferences" Kind="Class" />

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -3,13 +3,13 @@
     <Assembly Name="Microsoft.Caboodle" Version="1.0.0.0">
       <Attributes>
         <Attribute>
-          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.Default | System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints | System.Diagnostics.DebuggableAttribute+DebuggingModes.EnableEditAndContinue)</AttributeName>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyCompany("Microsoft")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyConfiguration("Debug")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyConfiguration("Release")</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")</AttributeName>


### PR DESCRIPTION
### Description of Change ###

Added the API to open the phone dialer.

### Bugs Fixed ###

- Related to issue #25
- Old PR #37 

### API Changes ###

```csharp
static class PhoneDialer {
    static void Open(string number);
}
```

### Behavioral Changes ###

Added the PhoneDialer API.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
