### PR TITLE
GH-18: Permissions Internal implementation

### DIFF
--- a/Caboodle/Battery/Battery.android.cs
+++ b/Caboodle/Battery/Battery.android.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Caboodle
             if (hasBatteryStatsPermission)
                 return;
 
-            Permissions.EnsureDeclaredAsync(PermissionType.Battery);
+            Permissions.EnsureDeclared(PermissionType.Battery);
 
             hasBatteryStatsPermission = true;
         }

--- a/Caboodle/Battery/Battery.android.cs
+++ b/Caboodle/Battery/Battery.android.cs
@@ -16,9 +16,7 @@ namespace Microsoft.Caboodle
             if (hasBatteryStatsPermission)
                 return;
 
-            var permission = Manifest.Permission.BatteryStats;
-            if (!Platform.HasPermissionInManifest(permission))
-                throw new PermissionException(permission);
+            Permissions.EnsureDeclaredAsync(PermissionType.Battery);
 
             hasBatteryStatsPermission = true;
         }

--- a/Caboodle/Caboodle.csproj
+++ b/Caboodle/Caboodle.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="26.1.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.Compat" Version="26.1.0.1" />
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
   </ItemGroup>

--- a/Caboodle/Caboodle.csproj
+++ b/Caboodle/Caboodle.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="26.1.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Compat" Version="26.1.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="26.1.0.1" />
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
   </ItemGroup>

--- a/Caboodle/Connectivity/Connectivity.android.cs
+++ b/Caboodle/Connectivity/Connectivity.android.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Caboodle
                 return;
 
             // Make sure the manifest has declared this permission
-            Permissions.EnsureDeclaredAsync(PermissionType.NetworkState);
+            Permissions.EnsureDeclared(PermissionType.NetworkState);
 
             hasPermission = true;
         }

--- a/Caboodle/Connectivity/Connectivity.android.cs
+++ b/Caboodle/Connectivity/Connectivity.android.cs
@@ -21,9 +21,8 @@ namespace Microsoft.Caboodle
             if (hasPermission)
                 return;
 
-            var permission = Manifest.Permission.AccessNetworkState;
-            if (!Platform.HasPermissionInManifest(permission))
-                throw new PermissionException(permission);
+            // Make sure the manifest has declared this permission
+            Permissions.EnsureDeclaredAsync(PermissionType.NetworkState);
 
             hasPermission = true;
         }

--- a/Caboodle/Permissions/PermissionEnums.shared.cs
+++ b/Caboodle/Permissions/PermissionEnums.shared.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Caboodle/Permissions/PermissionEnums.shared.cs
+++ b/Caboodle/Permissions/PermissionEnums.shared.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    internal enum PermissionStatus
+    {
+        // Denied by user
+        Denied,
+
+        // Feature is disabled on device
+        Disabled,
+
+        // Granted by user
+        Granted,
+
+        // Restricted (only iOS)
+        Restricted,
+
+        // Permission is in an unknown state
+        Unknown
+    }
+
+    internal enum PermissionType
+    {
+        Unknown,
+        Battery,
+        LocationWhenInUse,
+        NetworkState,
+    }
+}

--- a/Caboodle/Permissions/Permissions.android.cs
+++ b/Caboodle/Permissions/Permissions.android.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Caboodle/Permissions/Permissions.android.cs
+++ b/Caboodle/Permissions/Permissions.android.cs
@@ -47,12 +47,12 @@ namespace Microsoft.Caboodle
             if (androidPermissions == null || !androidPermissions.Any())
                 return Task.FromResult(PermissionStatus.Granted);
 
-            var hasApiM = Platform.HasApiLevel(Android.OS.BuildVersionCodes.M);
             var context = Platform.CurrentContext;
+            var targetsMOrHigher = context.ApplicationInfo.TargetSdkVersion >= Android.OS.BuildVersionCodes.M;
 
             foreach (var ap in androidPermissions)
             {
-                if (hasApiM)
+                if (targetsMOrHigher)
                 {
                     if (context.CheckSelfPermission(ap) != Permission.Granted)
                         return Task.FromResult(PermissionStatus.Denied);

--- a/Caboodle/Permissions/Permissions.android.cs
+++ b/Caboodle/Permissions/Permissions.android.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Android;
+using Android.Content.PM;
+using Android.Support.V4.App;
+using Android.Support.V4.Content;
+
+namespace Microsoft.Caboodle
+{
+    internal static partial class Permissions
+    {
+        static TaskCompletionSource<PermissionStatus> tcs;
+
+        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        {
+            var androidPermissions = permission.ToAndroidPermissions();
+
+            if (androidPermissions == null || !androidPermissions.Any())
+                return Task.CompletedTask;
+
+            var context = Platform.CurrentContext;
+
+            foreach (var ap in androidPermissions)
+            {
+                var packageInfo = context.PackageManager.GetPackageInfo(context.PackageName, PackageInfoFlags.Permissions);
+                var requestedPermissions = packageInfo?.RequestedPermissions;
+
+                if (!requestedPermissions?.Any(r => r.Equals(ap, StringComparison.OrdinalIgnoreCase)) ?? false)
+                    throw new PermissionException($"You need to declare the permission: `{ap}` in your AndroidManifest.xml");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
+        {
+            PlatformEnsureDeclaredAsync(permission);
+
+            var androidPermissions = permission.ToAndroidPermissions();
+
+            if (androidPermissions == null || !androidPermissions.Any())
+                return Task.FromResult(PermissionStatus.Unknown);
+
+            var hasApiM = Platform.HasApiLevel(Android.OS.BuildVersionCodes.M);
+            var context = Platform.CurrentContext;
+
+            foreach (var ap in androidPermissions)
+            {
+                if (hasApiM)
+                {
+                    if (context.CheckSelfPermission(ap) != Permission.Granted)
+                        return Task.FromResult(PermissionStatus.Denied);
+                }
+                else
+                {
+                    if (PermissionChecker.CheckSelfPermission(context, ap) != PermissionChecker.PermissionGranted)
+                        return Task.FromResult(PermissionStatus.Denied);
+                }
+            }
+
+            return Task.FromResult(PermissionStatus.Granted);
+        }
+
+        static async Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
+        {
+            if (await PlatformCheckStatusAsync(permission) == PermissionStatus.Granted)
+                return PermissionStatus.Granted;
+
+            var androidPermissions = permission.ToAndroidPermissions();
+
+            var activity = Platform.CurrentActivity;
+
+            tcs = new TaskCompletionSource<PermissionStatus>();
+
+            ActivityCompat.RequestPermissions(activity, androidPermissions.ToArray(), 24600913);
+
+            var result = await tcs.Task;
+
+            return result;
+        }
+    }
+
+    internal static class PermissionTypeExtensions
+    {
+        internal static string[] ToAndroidPermissions(this PermissionType permissionType)
+        {
+            switch (permissionType)
+            {
+                case PermissionType.Battery:
+                    return new[] { Manifest.Permission.BatteryStats };
+                case PermissionType.LocationWhenInUse:
+                    return new[] { Manifest.Permission.AccessFineLocation, Manifest.Permission.AccessCoarseLocation };
+                case PermissionType.NetworkState:
+                    return new[] { Manifest.Permission.AccessNetworkState };
+            }
+
+            return null;
+        }
+    }
+}

--- a/Caboodle/Permissions/Permissions.android.cs
+++ b/Caboodle/Permissions/Permissions.android.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Caboodle
     internal static partial class Permissions
     {
         static readonly object locker = new object();
+        static int requestCode = 0;
 
         static Dictionary<PermissionType, (int requestCode, TaskCompletionSource<PermissionStatus> tcs)> requests =
             new Dictionary<PermissionType, (int, TaskCompletionSource<PermissionStatus>)>();
@@ -76,7 +77,6 @@ namespace Microsoft.Caboodle
 
             TaskCompletionSource<PermissionStatus> tcs;
             var doRequest = true;
-            var requestCode = 0;
 
             lock (locker)
             {

--- a/Caboodle/Permissions/Permissions.android.cs
+++ b/Caboodle/Permissions/Permissions.android.cs
@@ -13,12 +13,13 @@ namespace Microsoft.Caboodle
     {
         static TaskCompletionSource<PermissionStatus> tcs;
 
-        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        static void PlatformEnsureDeclared(PermissionType permission)
         {
             var androidPermissions = permission.ToAndroidPermissions();
 
+            // No actual android permissions required here, just return
             if (androidPermissions == null || !androidPermissions.Any())
-                return Task.CompletedTask;
+                return;
 
             var context = Platform.CurrentContext;
 
@@ -27,16 +28,15 @@ namespace Microsoft.Caboodle
                 var packageInfo = context.PackageManager.GetPackageInfo(context.PackageName, PackageInfoFlags.Permissions);
                 var requestedPermissions = packageInfo?.RequestedPermissions;
 
+                // If the manifest is missing any of the permissions we need, throw
                 if (!requestedPermissions?.Any(r => r.Equals(ap, StringComparison.OrdinalIgnoreCase)) ?? false)
                     throw new PermissionException($"You need to declare the permission: `{ap}` in your AndroidManifest.xml");
             }
-
-            return Task.CompletedTask;
         }
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
         {
-            PlatformEnsureDeclaredAsync(permission);
+            PlatformEnsureDeclared(permission);
 
             var androidPermissions = permission.ToAndroidPermissions();
 

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -11,17 +11,18 @@ namespace Microsoft.Caboodle
     {
         static void PlatformEnsureDeclared(PermissionType permission)
         {
-            switch (permission)
+            var info = NSBundle.MainBundle.InfoDictionary;
+
+            if (permission == PermissionType.LocationWhenInUse)
             {
-                case PermissionType.LocationWhenInUse:
-                    EnsureLocationPermissionDeclared(permission);
-                    break;
+                if (!info.ContainsKey(new NSString("NSLocationWhenInUseUsageDescription")))
+                    throw new PermissionException("On iOS 8.0 and higher you must set either `NSLocationWhenInUseUsageDescription` or `NSLocationAlwaysUsageDescription` in your Info.plist file to enable Authorization Requests for Location updates!");
             }
         }
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
         {
-            EnsureLocationPermissionDeclared(permission);
+            PlatformEnsureDeclared(permission);
 
             switch (permission)
             {
@@ -34,7 +35,7 @@ namespace Microsoft.Caboodle
 
         static Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
         {
-            EnsureLocationPermissionDeclared(permission);
+            PlatformEnsureDeclared(permission);
 
             switch (permission)
             {
@@ -43,17 +44,6 @@ namespace Microsoft.Caboodle
             }
 
             return Task.FromResult(PermissionStatus.Granted);
-        }
-
-        static void EnsureLocationPermissionDeclared(PermissionType permission)
-        {
-            var info = NSBundle.MainBundle.InfoDictionary;
-
-            if (permission == PermissionType.LocationWhenInUse)
-            {
-                if (!info.ContainsKey(new NSString("NSLocationWhenInUseUsageDescription")))
-                    throw new PermissionException("On iOS 8.0 and higher you must set either `NSLocationWhenInUseUsageDescription` or `NSLocationAlwaysUsageDescription` in your Info.plist file to enable Authorization Requests for Location updates!");
-            }
         }
 
         static PermissionStatus GetLocationStatus()

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -99,20 +99,19 @@ namespace Microsoft.Caboodle
 
             var locationManager = new CLLocationManager();
 
-            EventHandler<CLAuthorizationChangedEventArgs> authCallback = null;
             var tcs = new TaskCompletionSource<PermissionStatus>();
 
-            authCallback = (sender, e) =>
+            void AuthCallback(object sender, CLAuthorizationChangedEventArgs e)
             {
                 if (e.Status == CLAuthorizationStatus.NotDetermined)
                     return;
 
-                locationManager.AuthorizationChanged -= authCallback;
+                locationManager.AuthorizationChanged -= AuthCallback;
 
                 tcs.TrySetResult(GetLocationStatus());
-            };
+            }
 
-            locationManager.AuthorizationChanged += authCallback;
+            locationManager.AuthorizationChanged += AuthCallback;
 
             locationManager.RequestWhenInUseAuthorization();
 

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Caboodle
 {
     internal static partial class Permissions
     {
-        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        static void PlatformEnsureDeclared(PermissionType permission)
         {
             switch (permission)
             {
@@ -17,8 +17,6 @@ namespace Microsoft.Caboodle
                     EnsureLocationPermissionDeclared(permission);
                     break;
             }
-
-            return Task.CompletedTask;
         }
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Caboodle
                     return Task.FromResult(GetLocationStatus());
             }
 
-            return Task.FromResult(PermissionStatus.Unknown);
+            return Task.FromResult(PermissionStatus.Granted);
         }
 
         static Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
@@ -42,7 +42,7 @@ namespace Microsoft.Caboodle
                     return RequestLocationAsync();
             }
 
-            return Task.FromResult(PermissionStatus.Unknown);
+            return Task.FromResult(PermissionStatus.Granted);
         }
 
         static void EnsureLocationPermissionDeclared(PermissionType permission)

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Caboodle
     {
         static void PlatformEnsureDeclared(PermissionType permission)
         {
+            // Info.plist declarations were only required in >= iOS 8.0
+            if (!Platform.HasOSVersion(8, 0))
+                return;
+
             var info = NSBundle.MainBundle.InfoDictionary;
 
             if (permission == PermissionType.LocationWhenInUse)
@@ -53,7 +57,7 @@ namespace Microsoft.Caboodle
 
             var status = CLLocationManager.Status;
 
-            if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+            if (Platform.HasOSVersion(8, 0))
             {
                 switch (status)
                 {

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CoreLocation;
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Caboodle
+{
+    internal static partial class Permissions
+    {
+        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        {
+            switch (permission)
+            {
+                case PermissionType.LocationWhenInUse:
+                    EnsureLocationPermissionDeclared(permission);
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
+        {
+            EnsureLocationPermissionDeclared(permission);
+
+            switch (permission)
+            {
+                case PermissionType.LocationWhenInUse:
+                    return Task.FromResult(GetLocationStatus());
+            }
+
+            return Task.FromResult(PermissionStatus.Unknown);
+        }
+
+        static Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
+        {
+            EnsureLocationPermissionDeclared(permission);
+
+            switch (permission)
+            {
+                case PermissionType.LocationWhenInUse:
+                    return RequestLocationAsync();
+            }
+
+            return Task.FromResult(PermissionStatus.Unknown);
+        }
+
+        static void EnsureLocationPermissionDeclared(PermissionType permission)
+        {
+            var info = NSBundle.MainBundle.InfoDictionary;
+
+            if (permission == PermissionType.LocationWhenInUse)
+            {
+                if (!info.ContainsKey(new NSString("NSLocationWhenInUseUsageDescription")))
+                    throw new PermissionException("On iOS 8.0 and higher you must set either `NSLocationWhenInUseUsageDescription` or `NSLocationAlwaysUsageDescription` in your Info.plist file to enable Authorization Requests for Location updates!");
+            }
+        }
+
+        static PermissionStatus GetLocationStatus()
+        {
+            if (!CLLocationManager.LocationServicesEnabled)
+                return PermissionStatus.Disabled;
+
+            var status = CLLocationManager.Status;
+
+            if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+            {
+                switch (status)
+                {
+                    case CLAuthorizationStatus.AuthorizedAlways:
+                    case CLAuthorizationStatus.AuthorizedWhenInUse:
+                        return PermissionStatus.Granted;
+                    case CLAuthorizationStatus.Denied:
+                        return PermissionStatus.Denied;
+                    case CLAuthorizationStatus.Restricted:
+                        return PermissionStatus.Restricted;
+                    default:
+                        return PermissionStatus.Unknown;
+                }
+            }
+
+            switch (status)
+            {
+                case CLAuthorizationStatus.Authorized:
+                    return PermissionStatus.Granted;
+                case CLAuthorizationStatus.Denied:
+                    return PermissionStatus.Denied;
+                case CLAuthorizationStatus.Restricted:
+                    return PermissionStatus.Restricted;
+                default:
+                    return PermissionStatus.Unknown;
+            }
+        }
+
+        static Task<PermissionStatus> RequestLocationAsync()
+        {
+            if (!UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+                return Task.FromResult(PermissionStatus.Unknown);
+
+            var locationManager = new CLLocationManager();
+
+            EventHandler<CLAuthorizationChangedEventArgs> authCallback = null;
+            var tcs = new TaskCompletionSource<PermissionStatus>();
+
+            authCallback = (sender, e) =>
+            {
+                if (e.Status == CLAuthorizationStatus.NotDetermined)
+                    return;
+
+                locationManager.AuthorizationChanged -= authCallback;
+
+                tcs.TrySetResult(GetLocationStatus());
+            };
+
+            locationManager.AuthorizationChanged += authCallback;
+
+            locationManager.RequestWhenInUseAuthorization();
+
+            return tcs.Task;
+        }
+    }
+}

--- a/Caboodle/Permissions/Permissions.ios.cs
+++ b/Caboodle/Permissions/Permissions.ios.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CoreLocation;

--- a/Caboodle/Permissions/Permissions.netstandard.cs
+++ b/Caboodle/Permissions/Permissions.netstandard.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Caboodle/Permissions/Permissions.netstandard.cs
+++ b/Caboodle/Permissions/Permissions.netstandard.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    internal static partial class Permissions
+    {
+        static Task PlatformEnsureDeclaredAsync(PermissionType permission) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static Task<PermissionStatus> PlatformRequestAsync(PermissionType permission) =>
+            throw new NotImplementedInReferenceAssemblyException();
+    }
+}

--- a/Caboodle/Permissions/Permissions.netstandard.cs
+++ b/Caboodle/Permissions/Permissions.netstandard.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Caboodle
 {
     internal static partial class Permissions
     {
-        static Task PlatformEnsureDeclaredAsync(PermissionType permission) =>
+        static void PlatformEnsureDeclared(PermissionType permission) =>
             throw new NotImplementedInReferenceAssemblyException();
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission) =>

--- a/Caboodle/Permissions/Permissions.shared.cs
+++ b/Caboodle/Permissions/Permissions.shared.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Caboodle/Permissions/Permissions.shared.cs
+++ b/Caboodle/Permissions/Permissions.shared.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Caboodle
 {
     internal static partial class Permissions
     {
-        internal static Task EnsureDeclaredAsync(PermissionType permission) =>
-            PlatformEnsureDeclaredAsync(permission);
+        internal static void EnsureDeclared(PermissionType permission) =>
+            PlatformEnsureDeclared(permission);
 
         internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission) =>
             PlatformCheckStatusAsync(permission);

--- a/Caboodle/Permissions/Permissions.shared.cs
+++ b/Caboodle/Permissions/Permissions.shared.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Caboodle
+{
+    internal static partial class Permissions
+    {
+        internal static Task EnsureDeclaredAsync(PermissionType permission) =>
+            PlatformEnsureDeclaredAsync(permission);
+
+        internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission) =>
+            PlatformCheckStatusAsync(permission);
+
+        internal static Task<PermissionStatus> RequestAsync(PermissionType permission) =>
+            PlatformRequestAsync(permission);
+    }
+}

--- a/Caboodle/Permissions/Permissions.uwp.cs
+++ b/Caboodle/Permissions/Permissions.uwp.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Caboodle/Permissions/Permissions.uwp.cs
+++ b/Caboodle/Permissions/Permissions.uwp.cs
@@ -13,23 +13,23 @@ namespace Microsoft.Caboodle
         const string appManifestFilename = "AppxManifest.xml";
         const string appManifestXmlns = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
 
-        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        static void PlatformEnsureDeclared(PermissionType permission)
         {
             var uwpCapabilities = permission.ToUWPCapabilities();
 
+            // If no actual UWP capabilities are required here, just return
             if (uwpCapabilities == null || !uwpCapabilities.Any())
-                return Task.CompletedTask;
+                return;
 
             var doc = XDocument.Load(appManifestFilename, LoadOptions.None);
             var xname = XNamespace.Get(appManifestXmlns);
 
             foreach (var cap in uwpCapabilities)
             {
+                // If the manifest doesn't contain a capability we need, throw
                 if (!doc.Root.XPathSelectElements($"//{xname}Capabilities[@Name='{cap}'")?.Any() ?? false)
                     throw new PermissionException($"You need to declare the capability `{cap}` in your AppxManifest.xml file");
             }
-
-            return Task.CompletedTask;
         }
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)

--- a/Caboodle/Permissions/Permissions.uwp.cs
+++ b/Caboodle/Permissions/Permissions.uwp.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Windows.Devices.Geolocation;
+
+namespace Microsoft.Caboodle
+{
+    internal static partial class Permissions
+    {
+        const string appManifestFilename = "AppxManifest.xml";
+        const string appManifestXmlns = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
+
+        static Task PlatformEnsureDeclaredAsync(PermissionType permission)
+        {
+            var uwpCapabilities = permission.ToUWPCapabilities();
+
+            if (uwpCapabilities == null || !uwpCapabilities.Any())
+                return Task.CompletedTask;
+
+            var doc = XDocument.Load(appManifestFilename, LoadOptions.None);
+            var xname = XNamespace.Get(appManifestXmlns);
+
+            foreach (var cap in uwpCapabilities)
+            {
+                if (!doc.Root.XPathSelectElements($"//{xname}Capabilities[@Name='{cap}'")?.Any() ?? false)
+                    throw new PermissionException($"You need to declare the capability `{cap}` in your AppxManifest.xml file");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
+        {
+            switch (permission)
+            {
+                case PermissionType.LocationWhenInUse:
+                    return CheckLocationAsync();
+            }
+
+            return Task.FromResult(PermissionStatus.Granted);
+        }
+
+        static Task<PermissionStatus> PlatformRequestAsync(PermissionType permission) =>
+            PlatformCheckStatusAsync(permission);
+
+        static async Task<PermissionStatus> CheckLocationAsync()
+        {
+            var accessStatus = await Geolocator.RequestAccessAsync();
+
+            switch (accessStatus)
+            {
+                case GeolocationAccessStatus.Allowed:
+                    return PermissionStatus.Granted;
+                case GeolocationAccessStatus.Unspecified:
+                    return PermissionStatus.Unknown;
+            }
+
+            return PermissionStatus.Denied;
+        }
+    }
+
+    internal static class PermissionTypeExtensions
+    {
+        internal static string[] ToUWPCapabilities(this PermissionType permissionType)
+        {
+            switch (permissionType)
+            {
+                case PermissionType.LocationWhenInUse:
+                    return new[] { "location" };
+            }
+
+            return null;
+        }
+    }
+}

--- a/Caboodle/Platform/Platform.android.cs
+++ b/Caboodle/Platform/Platform.android.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Caboodle
         public static void Init(Activity activity, Bundle bundle) =>
            Init(activity.Application);
 
+        public static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults) =>
+            Permissions.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
         internal static bool IsIntentSupported(Intent intent)
         {
             var manager = CurrentContext.PackageManager;

--- a/Caboodle/Platform/Platform.android.cs
+++ b/Caboodle/Platform/Platform.android.cs
@@ -29,13 +29,6 @@ namespace Microsoft.Caboodle
         public static void Init(Activity activity, Bundle bundle) =>
            Init(activity.Application);
 
-        internal static bool HasPermissionInManifest(string permission)
-        {
-            var packageInfo = CurrentContext.PackageManager.GetPackageInfo(CurrentContext.PackageName, PackageInfoFlags.Permissions);
-            var requestedPermissions = packageInfo?.RequestedPermissions;
-            return requestedPermissions?.Any(r => r.Equals(permission, StringComparison.InvariantCultureIgnoreCase)) ?? false;
-        }
-
         internal static bool IsIntentSupported(Intent intent)
         {
             var manager = CurrentContext.PackageManager;

--- a/Caboodle/Platform/Platform.ios.cs
+++ b/Caboodle/Platform/Platform.ios.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Caboodle
 
             NSRunLoop.Main.BeginInvokeOnMainThread(action.Invoke);
         }
+        internal static bool HasOSVersion(int major, int minor) =>
+            UIDevice.CurrentDevice.CheckSystemVersion(major, minor);
 
         internal static UIViewController GetCurrentViewController(bool throwIfNull = true)
         {

--- a/Caboodle/Platform/Platform.ios.cs
+++ b/Caboodle/Platform/Platform.ios.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Caboodle
 
             NSRunLoop.Main.BeginInvokeOnMainThread(action.Invoke);
         }
+
         internal static bool HasOSVersion(int major, int minor) =>
             UIDevice.CurrentDevice.CheckSystemVersion(major, minor);
 

--- a/Caboodle/Types/Shared/Exceptions.shared.cs
+++ b/Caboodle/Types/Shared/Exceptions.shared.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Caboodle
 
     public class PermissionException : UnauthorizedAccessException
     {
-        public PermissionException(string permission)
-            : base($"API requires the {permission} permission to be set.")
+        public PermissionException(string message)
+            : base(message)
         {
         }
     }

--- a/DeviceTests/Caboodle.DeviceTests.Android/MainActivity.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Android/MainActivity.cs
@@ -2,6 +2,7 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Android.Runtime;
 using Xunit.Runners.UI;
 
 namespace Caboodle.DeviceTests.Droid

--- a/DeviceTests/Caboodle.DeviceTests.Android/MainActivity.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Android/MainActivity.cs
@@ -39,5 +39,12 @@ namespace Caboodle.DeviceTests.Droid
             // you cannot add more assemblies once calling base
             base.OnCreate(bundle);
         }
+
+        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Permission[] grantResults)
+        {
+            Microsoft.Caboodle.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
+            base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
     }
 }

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Caboodle.DeviceTests.Shared.projitems
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Caboodle.DeviceTests.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Clipboard_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceInfo_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Geocoding_Tests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Permissions_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PhoneDialer_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScreenLock_Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Preferences_Tests.cs" />

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 using Microsoft.Caboodle;
 using Xunit;
 
+#if __ANDROID__
+[assembly: Android.App.UsesPermission(Android.Manifest.Permission.BatteryStats)]
+#endif
+
 namespace Caboodle.DeviceTests
 {
     public class Permissions_Tests

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Caboodle;
+using Xunit;
+
+namespace Caboodle.DeviceTests
+{
+    public class Permissions_Tests
+    {
+        [Theory]
+        [InlineData(PermissionType.Battery)]
+        [InlineData(PermissionType.NetworkState)]
+        [InlineData(PermissionType.LocationWhenInUse)]
+        internal void Ensure_Declared(PermissionType permission)
+        {
+            Permissions.EnsureDeclared(permission);
+        }
+
+        [Theory]
+        [InlineData(PermissionType.Battery, PermissionStatus.Granted)]
+        [InlineData(PermissionType.NetworkState, PermissionStatus.Granted)]
+        [InlineData(PermissionType.LocationWhenInUse, PermissionStatus.Granted)]
+        internal async Task Check_Status(PermissionType permission, PermissionStatus expectedStatus)
+        {
+            var status = await Permissions.CheckStatusAsync(permission);
+
+            Assert.Equal(expectedStatus, status);
+        }
+
+        [Theory]
+        [InlineData(PermissionType.Battery, PermissionStatus.Granted)]
+        [InlineData(PermissionType.NetworkState, PermissionStatus.Granted)]
+        internal async Task Request(PermissionType permission, PermissionStatus expectedStatus)
+        {
+            var status = await Permissions.CheckStatusAsync(permission);
+
+            Assert.Equal(expectedStatus, status);
+        }
+    }
+}

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
@@ -12,16 +12,22 @@ namespace Caboodle.DeviceTests
         [Theory]
         [InlineData(PermissionType.Battery)]
         [InlineData(PermissionType.NetworkState)]
-        [InlineData(PermissionType.LocationWhenInUse)]
         internal void Ensure_Declared(PermissionType permission)
         {
             Permissions.EnsureDeclared(permission);
         }
 
         [Theory]
+        [InlineData(PermissionType.LocationWhenInUse)]
+        internal void Ensure_Declared_Throws(PermissionType permission)
+        {
+            Assert.Throws<PermissionException>(() => Permissions.EnsureDeclared(permission));
+        }
+
+        [Theory]
         [InlineData(PermissionType.Battery, PermissionStatus.Granted)]
         [InlineData(PermissionType.NetworkState, PermissionStatus.Granted)]
-        [InlineData(PermissionType.LocationWhenInUse, PermissionStatus.Granted)]
+        [InlineData(PermissionType.LocationWhenInUse, PermissionStatus.Denied)]
         internal async Task Check_Status(PermissionType permission, PermissionStatus expectedStatus)
         {
             var status = await Permissions.CheckStatusAsync(permission);

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
@@ -27,12 +27,18 @@ namespace Caboodle.DeviceTests
         [Theory]
         [InlineData(PermissionType.Battery, PermissionStatus.Granted)]
         [InlineData(PermissionType.NetworkState, PermissionStatus.Granted)]
-        [InlineData(PermissionType.LocationWhenInUse, PermissionStatus.Denied)]
         internal async Task Check_Status(PermissionType permission, PermissionStatus expectedStatus)
         {
             var status = await Permissions.CheckStatusAsync(permission);
 
             Assert.Equal(expectedStatus, status);
+        }
+
+        [Theory]
+        [InlineData(PermissionType.LocationWhenInUse)]
+        internal Task Check_Status_Throws(PermissionType permission)
+        {
+            return Assert.ThrowsAsync<PermissionException>(async () => await Permissions.CheckStatusAsync(permission));
         }
 
         [Theory]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The following cross-platform APIs are planned for our first release:
  - [ ] Gyroscope
  - [ ] Magnetometer
  - [x] Open Browser
- - [ ] Permissions
  - [x] Phone Dialer
  - [x] Preferences
  - [x] Screen Lock

--- a/Samples/Caboodle.Samples.Android/MainActivity.cs
+++ b/Samples/Caboodle.Samples.Android/MainActivity.cs
@@ -1,6 +1,7 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Android.Runtime;
 
 namespace Caboodle.Samples.Droid
 {
@@ -17,6 +18,13 @@ namespace Caboodle.Samples.Droid
             Microsoft.Caboodle.Platform.Init(this, bundle);
             Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
+        }
+
+        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Permission[] grantResults)
+        {
+            Microsoft.Caboodle.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
+            base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Some API's require checking permissions.  This adds some (currently) internal API's for checking permissions and requesting them.

Currently this only supports permission types which we need for other API's (`Battery`, `NetworkAccess1, and `LocationWhileInUse`).  We can add more types as we encounter the need for them.


### API Changes ###

List all API changes here (or just put None), example:

Added: 

```csharp
internal static class Permissions {
    // Throws a relevant PermissionException if permissions aren't declared in:
    //   AndroidManifest.xml / Info.plist / AppxManifest.xml
    internal static Task EnsureDeclaredAsync(PermissionType permission);

    // Checks the permission status
    internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission);

    // Requests permission
    internal static Task<PermissionStatus> RequestAsync(PermissionType permission);
}
```

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))