### PR TITLE
Make Device Test results specify platform in names

### DIFF
--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -43,6 +43,15 @@ Func<int, FilePath, Task> DownloadTcpTextAsync = (int port, FilePath filename) =
             stream.CopyTo(file);
     });
 
+Action<FilePath, string> AddPlatformToTestResults = (FilePath testResultsFile, string platformName) => {
+    if (FileExists(testResultsFile)) {
+        var txt = FileReadText(testResultsFile);
+        txt = txt.Replace("<test-case name=\"Caboodle.DeviceTests.", $"<test-case name=\"Caboodle.DeviceTests.{platformName}.");
+        txt = txt.Replace("name=\"Test collection for Caboodle.DeviceTests.", $"name=\"Test collection for Caboodle.DeviceTests.{platformName}.");        
+        FileWriteText(testResultsFile, txt);
+    }
+};
+
 Task ("build-ios")
     .Does (() =>
 {
@@ -106,6 +115,8 @@ Task ("test-ios-emu")
     // Wait for the TCP listener to get results
     Information("Waiting for tests...");
     tcpListenerTask.Wait ();
+
+    AddPlatformToTestResults(IOS_TEST_RESULTS_PATH, "iOS");
 
     // Close up simulators
     Information("Closing Simulator");
@@ -215,6 +226,8 @@ Task ("test-android-emu")
     Information("Waiting for tests...");
     tcpListenerTask.Wait ();
 
+    AddPlatformToTestResults(ANDROID_TEST_RESULTS_PATH, "Android");
+
     // Close emulator
     emu.Kill();
 });
@@ -271,6 +284,8 @@ Task ("test-uwp-emu")
     // Wait for the test results to come back
     Information("Waiting for tests...");
     tcpListenerTask.Wait ();
+
+    AddPlatformToTestResults(UWP_TEST_RESULTS_PATH, "UWP");
 
     // Uninstall the app (this will terminate it too)
     uninstallPS();


### PR DESCRIPTION
One drawback to a shared test project is that the namespace and class names aren’t descriptive of the platform they are running on.  When merging all the test results in CI systems, we lose the ability to easily identify where a test case was ran (especially if it failed).

This will quickly replace some text in the test results file to be specific about the platform each test was run on.

### PR Checklist ###

- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
