### PR TITLE
GH-145 Adjust Package References for Android

### DIFF
--- a/Caboodle/Caboodle.csproj
+++ b/Caboodle/Caboodle.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <!--Work around so the conditions work below-->
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid71;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid71;</TargetFrameworks>
     <AssemblyName>Microsoft.Caboodle</AssemblyName>
     <RootNamespace>Microsoft.Caboodle</RootNamespace>
     <PackageId>Microsoft.Caboodle</PackageId>
@@ -58,8 +58,10 @@
     <Compile Include="**\*.uwp.*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="26.1.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="26.1.0.1" />
+    
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="25.4.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="25.4.0.2" />
+    
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
   </ItemGroup>

--- a/Caboodle/Vibration/Vibration.android.cs
+++ b/Caboodle/Vibration/Vibration.android.cs
@@ -13,16 +13,19 @@ namespace Microsoft.Caboodle
             Permissions.EnsureDeclared(PermissionType.Vibrate);
 
             var time = (long)duration.TotalMilliseconds;
+#if __ANDROID_26__
             if (Platform.HasApiLevel(BuildVersionCodes.O))
             {
                 Platform.Vibrator.Vibrate(VibrationEffect.CreateOneShot(time, VibrationEffect.DefaultAmplitude));
             }
             else
+#else
             {
 #pragma warning disable CS0618 // Type or member is obsolete
                 Platform.Vibrator.Vibrate(time);
 #pragma warning restore CS0618 // Type or member is obsolete
             }
+#endif
         }
 
         static void PlatformCancel()


### PR DESCRIPTION
### Description of Change ###

Match Xamarin.Forms for Android NuGet Libraries.
Can no longer use fancy Android 8 Features, so if def them for now.

### Bugs Fixed ###

- Related to issue #145 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

Changed:

 - Vibrate will always fall back to classic.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
