### PR TITLE
GH-150 Fix tests for UWP on compass, flashlight, clipboard, and permissions!

### DIFF
--- a/Caboodle/Compass/Compass.uwp.cs
+++ b/Caboodle/Compass/Compass.uwp.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Caboodle
 
         internal static void PlatformStop()
         {
+            if (sensor == null)
+                return;
+
             sensor.ReadingChanged -= CompassReportedInterval;
         }
     }

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Clipboard_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Clipboard_Tests.cs
@@ -11,9 +11,11 @@ namespace Caboodle.DeviceTests
         [InlineData("some really long test text")]
         public Task Set_Clipboard_Values(string text)
         {
-            return Utils.OnMainThread(() =>
+            return Utils.OnMainThread(async () =>
             {
                 Clipboard.SetText(text);
+
+                await Task.Delay(100);
 
                 Assert.True(Clipboard.HasText);
             });

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Compass_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Compass_Tests.cs
@@ -7,6 +7,11 @@ namespace Caboodle.DeviceTests
 {
     public class Compass_Tests
     {
+        bool TestSupported =>
+               DeviceInfo.Platform == DeviceInfo.Platforms.Android ||
+               DeviceInfo.Platform == DeviceInfo.Platforms.UWP ||
+               (DeviceInfo.DeviceType == DeviceType.Physical && DeviceInfo.Platform == DeviceInfo.Platforms.iOS);
+
         public Compass_Tests()
         {
             Compass.Stop();
@@ -15,7 +20,7 @@ namespace Caboodle.DeviceTests
         [Fact]
         public void IsSupported()
         {
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && DeviceInfo.Platform == DeviceInfo.Platforms.iOS)
+            if (!TestSupported)
             {
                 Assert.False(Compass.IsSupported);
                 return;
@@ -28,7 +33,7 @@ namespace Caboodle.DeviceTests
         [InlineData(SensorSpeed.Fastest)]
         public async Task Monitor(SensorSpeed sensorSpeed)
         {
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && DeviceInfo.Platform == DeviceInfo.Platforms.iOS)
+            if (!TestSupported)
             {
                 return;
             }
@@ -53,7 +58,7 @@ namespace Caboodle.DeviceTests
         [InlineData(SensorSpeed.Fastest)]
         public async Task IsMonitoring(SensorSpeed sensorSpeed)
         {
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && DeviceInfo.Platform == DeviceInfo.Platforms.iOS)
+            if (!TestSupported)
             {
                 return;
             }
@@ -77,7 +82,7 @@ namespace Caboodle.DeviceTests
         [InlineData(SensorSpeed.Fastest)]
         public async Task Stop_Monitor(SensorSpeed sensorSpeed)
         {
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && DeviceInfo.Platform == DeviceInfo.Platforms.iOS)
+            if (!TestSupported)
             {
                 return;
             }

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Flashlight_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Flashlight_Tests.cs
@@ -14,6 +14,14 @@ namespace Caboodle.DeviceTests
         [InlineData(false)]
         public async Task Turn_On_Off(bool oldCameraApi)
         {
+            if (DeviceInfo.Platform == DeviceInfo.Platforms.UWP)
+            {
+                await Utils.OnMainThread(async () =>
+                {
+                    await Assert.ThrowsAsync<FeatureNotSupportedException>(() => Flashlight.TurnOnAsync());
+                });
+                return;
+            }
 #if __ANDROID__
             // API 23+ we need user interaction for camera permission
             // can't really test so easily on device.

--- a/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/Caboodle.DeviceTests.Shared/Permissions_Tests.cs
@@ -25,6 +25,11 @@ namespace Caboodle.DeviceTests
         [InlineData(PermissionType.LocationWhenInUse)]
         internal void Ensure_Declared_Throws(PermissionType permission)
         {
+            if (DeviceInfo.Platform == DeviceInfo.Platforms.UWP)
+            {
+                return;
+            }
+
             Assert.Throws<PermissionException>(() => Permissions.EnsureDeclared(permission));
         }
 
@@ -42,6 +47,11 @@ namespace Caboodle.DeviceTests
         [InlineData(PermissionType.LocationWhenInUse)]
         internal Task Check_Status_Throws(PermissionType permission)
         {
+            if (DeviceInfo.Platform == DeviceInfo.Platforms.UWP)
+            {
+                return Task.CompletedTask;
+            }
+
             return Assert.ThrowsAsync<PermissionException>(async () => await Permissions.CheckStatusAsync(permission));
         }
 

--- a/DeviceTests/Caboodle.DeviceTests.UWP/Package.appxmanifest
+++ b/DeviceTests/Caboodle.DeviceTests.UWP/Package.appxmanifest
@@ -33,5 +33,6 @@
     <Capability Name="internetClient" />
     <Capability Name="internetClientServer" />
     <Capability Name="privateNetworkClientServer" />
+    <DeviceCapability Name="location" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #150


### API Changes ###

List all API changes here (or just put None), example:
None

### Behavioral Changes ###

No longer run certain tests on UWP due to permissions.
Check for null sensor on windows.
Run certain tests on ui thread for UWP.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
